### PR TITLE
Run the `helm lint` command when HELM_COMMAND=lint

### DIFF
--- a/internal/helm/plan.go
+++ b/internal/helm/plan.go
@@ -62,7 +62,7 @@ func determineSteps(cfg Config) *func(Config) []Step {
 	case "delete":
 		panic("not implemented")
 	case "lint":
-		panic("not implemented")
+		return &lint
 	case "help":
 		return &help
 	default:
@@ -114,6 +114,14 @@ var upgrade = func(cfg Config) []Step {
 	})
 
 	return steps
+}
+
+var lint = func(cfg Config) []Step {
+	lint := &run.Lint{
+		Chart: cfg.Chart,
+	}
+
+	return []Step{lint}
 }
 
 var help = func(cfg Config) []Step {

--- a/internal/helm/plan_test.go
+++ b/internal/helm/plan_test.go
@@ -137,6 +137,20 @@ func (suite *PlanTestSuite) TestUpgrade() {
 	suite.Equal(expected, upgrade)
 }
 
+func (suite *PlanTestSuite) TestLint() {
+	cfg := Config{
+		Chart: "./flow",
+	}
+
+	steps := lint(cfg)
+	suite.Equal(1, len(steps))
+
+	want := &run.Lint{
+		Chart: "./flow",
+	}
+	suite.Equal(want, steps[0])
+}
+
 func (suite *PlanTestSuite) TestDeterminePlanUpgradeCommand() {
 	cfg := Config{
 		Command: "upgrade",
@@ -154,6 +168,15 @@ func (suite *PlanTestSuite) TestDeterminePlanUpgradeFromDroneEvent() {
 		stepsMaker := determineSteps(cfg)
 		suite.Same(&upgrade, stepsMaker, fmt.Sprintf("for event type '%s'", event))
 	}
+}
+
+func (suite *PlanTestSuite) TestDeterminePlanLintCommand() {
+	cfg := Config{
+		Command: "lint",
+	}
+
+	stepsMaker := determineSteps(cfg)
+	suite.Same(&lint, stepsMaker)
 }
 
 func (suite *PlanTestSuite) TestDeterminePlanHelpCommand() {

--- a/internal/run/lint.go
+++ b/internal/run/lint.go
@@ -1,0 +1,28 @@
+package run
+
+import (
+// "fmt"
+)
+
+// Lint is an execution step that calls `helm lint` when executed.
+type Lint struct {
+	Chart string
+
+	cmd cmd
+}
+
+// Execute executes the `helm lint` command.
+func (l *Lint) Execute(_ Config) error {
+	return l.cmd.Run()
+}
+
+// Prepare gets the Lint ready to execute.
+func (l *Lint) Prepare(cfg Config) error {
+	args := []string{"lint", l.Chart}
+
+	l.cmd = command(helmBin, args...)
+	l.cmd.Stdout(cfg.Stdout)
+	l.cmd.Stderr(cfg.Stderr)
+
+	return nil
+}

--- a/internal/run/lint.go
+++ b/internal/run/lint.go
@@ -1,7 +1,7 @@
 package run
 
 import (
-// "fmt"
+	"fmt"
 )
 
 // Lint is an execution step that calls `helm lint` when executed.
@@ -18,7 +18,13 @@ func (l *Lint) Execute(_ Config) error {
 
 // Prepare gets the Lint ready to execute.
 func (l *Lint) Prepare(cfg Config) error {
-	args := []string{"lint"}
+	args := make([]string, 0)
+
+	if cfg.Debug {
+		args = append(args, "--debug")
+	}
+
+	args = append(args, "lint")
 
 	if cfg.Values != "" {
 		args = append(args, "--set", cfg.Values)
@@ -35,6 +41,10 @@ func (l *Lint) Prepare(cfg Config) error {
 	l.cmd = command(helmBin, args...)
 	l.cmd.Stdout(cfg.Stdout)
 	l.cmd.Stderr(cfg.Stderr)
+
+	if cfg.Debug {
+		fmt.Fprintf(cfg.Stderr, "Generated command: '%s'\n", l.cmd.String())
+	}
 
 	return nil
 }

--- a/internal/run/lint.go
+++ b/internal/run/lint.go
@@ -18,6 +18,10 @@ func (l *Lint) Execute(_ Config) error {
 
 // Prepare gets the Lint ready to execute.
 func (l *Lint) Prepare(cfg Config) error {
+	if l.Chart == "" {
+		return fmt.Errorf("chart is required")
+	}
+
 	args := make([]string, 0)
 
 	if cfg.Debug {

--- a/internal/run/lint.go
+++ b/internal/run/lint.go
@@ -7,8 +7,7 @@ import (
 // Lint is an execution step that calls `helm lint` when executed.
 type Lint struct {
 	Chart string
-
-	cmd cmd
+	cmd   cmd
 }
 
 // Execute executes the `helm lint` command.

--- a/internal/run/lint.go
+++ b/internal/run/lint.go
@@ -18,7 +18,19 @@ func (l *Lint) Execute(_ Config) error {
 
 // Prepare gets the Lint ready to execute.
 func (l *Lint) Prepare(cfg Config) error {
-	args := []string{"lint", l.Chart}
+	args := []string{"lint"}
+
+	if cfg.Values != "" {
+		args = append(args, "--set", cfg.Values)
+	}
+	if cfg.StringValues != "" {
+		args = append(args, "--set-string", cfg.StringValues)
+	}
+	for _, vFile := range cfg.ValuesFiles {
+		args = append(args, "--values", vFile)
+	}
+
+	args = append(args, l.Chart)
 
 	l.cmd = command(helmBin, args...)
 	l.cmd.Stdout(cfg.Stdout)

--- a/internal/run/lint.go
+++ b/internal/run/lint.go
@@ -24,6 +24,9 @@ func (l *Lint) Prepare(cfg Config) error {
 
 	args := make([]string, 0)
 
+	if cfg.Namespace != "" {
+		args = append(args, "--namespace", cfg.Namespace)
+	}
 	if cfg.Debug {
 		args = append(args, "--debug")
 	}

--- a/internal/run/lint_test.go
+++ b/internal/run/lint_test.go
@@ -56,3 +56,35 @@ func (suite *LintTestSuite) TestPrepareAndExecute() {
 	suite.Require().Nil(err)
 	l.Execute(cfg)
 }
+
+func (suite *LintTestSuite) TestPrepareWithLintFlags() {
+	defer suite.ctrl.Finish()
+
+	cfg := Config{
+		Values:       "width=5",
+		StringValues: "version=2.0",
+		ValuesFiles:  []string{"/usr/local/underrides", "/usr/local/overrides"},
+	}
+
+	l := Lint{
+		Chart: "./uk/top_40",
+	}
+
+	command = func(path string, args ...string) cmd {
+		suite.Equal(helmBin, path)
+		suite.Equal([]string{"lint",
+			"--set", "width=5",
+			"--set-string", "version=2.0",
+			"--values", "/usr/local/underrides",
+			"--values", "/usr/local/overrides",
+			"./uk/top_40"}, args)
+
+		return suite.mockCmd
+	}
+
+	suite.mockCmd.EXPECT().Stdout(gomock.Any())
+	suite.mockCmd.EXPECT().Stderr(gomock.Any())
+
+	err := l.Prepare(cfg)
+	suite.Require().Nil(err)
+}

--- a/internal/run/lint_test.go
+++ b/internal/run/lint_test.go
@@ -59,6 +59,18 @@ func (suite *LintTestSuite) TestPrepareAndExecute() {
 	l.Execute(cfg)
 }
 
+func (suite *LintTestSuite) TestPrepareRequiresChart() {
+	// These aren't really expected, but allowing them gives clearer test-failure messages
+	suite.mockCmd.EXPECT().Stdout(gomock.Any())
+	suite.mockCmd.EXPECT().Stderr(gomock.Any())
+
+	cfg := Config{}
+	l := Lint{}
+
+	err := l.Prepare(cfg)
+	suite.EqualError(err, "chart is required", "Chart should be mandatory")
+}
+
 func (suite *LintTestSuite) TestPrepareWithLintFlags() {
 	defer suite.ctrl.Finish()
 

--- a/internal/run/lint_test.go
+++ b/internal/run/lint_test.go
@@ -34,8 +34,15 @@ func TestLintTestSuite(t *testing.T) {
 func (suite *LintTestSuite) TestPrepareAndExecute() {
 	defer suite.ctrl.Finish()
 
+	stdout := strings.Builder{}
+	stderr := strings.Builder{}
+
 	l := Lint{
 		Chart: "./epic/mychart",
+	}
+	cfg := Config{
+		Stdout: &stdout,
+		Stderr: &stderr,
 	}
 
 	command = func(path string, args ...string) cmd {
@@ -46,14 +53,13 @@ func (suite *LintTestSuite) TestPrepareAndExecute() {
 	}
 
 	suite.mockCmd.EXPECT().
-		Stdout(gomock.Any())
+		Stdout(&stdout)
 	suite.mockCmd.EXPECT().
-		Stderr(gomock.Any())
+		Stderr(&stderr)
 	suite.mockCmd.EXPECT().
 		Run().
 		Times(1)
 
-	cfg := Config{}
 	err := l.Prepare(cfg)
 	suite.Require().Nil(err)
 	l.Execute(cfg)

--- a/internal/run/lint_test.go
+++ b/internal/run/lint_test.go
@@ -61,8 +61,8 @@ func (suite *LintTestSuite) TestPrepareAndExecute() {
 
 func (suite *LintTestSuite) TestPrepareRequiresChart() {
 	// These aren't really expected, but allowing them gives clearer test-failure messages
-	suite.mockCmd.EXPECT().Stdout(gomock.Any())
-	suite.mockCmd.EXPECT().Stderr(gomock.Any())
+	suite.mockCmd.EXPECT().Stdout(gomock.Any()).AnyTimes()
+	suite.mockCmd.EXPECT().Stderr(gomock.Any()).AnyTimes()
 
 	cfg := Config{}
 	l := Lint{}
@@ -96,8 +96,8 @@ func (suite *LintTestSuite) TestPrepareWithLintFlags() {
 		return suite.mockCmd
 	}
 
-	suite.mockCmd.EXPECT().Stdout(gomock.Any())
-	suite.mockCmd.EXPECT().Stderr(gomock.Any())
+	suite.mockCmd.EXPECT().Stdout(gomock.Any()).AnyTimes()
+	suite.mockCmd.EXPECT().Stderr(gomock.Any()).AnyTimes()
 
 	err := l.Prepare(cfg)
 	suite.Require().Nil(err)
@@ -126,7 +126,7 @@ func (suite *LintTestSuite) TestPrepareWithDebugFlag() {
 	}
 
 	suite.mockCmd.EXPECT().Stdout(gomock.Any())
-	suite.mockCmd.EXPECT().Stderr(gomock.Any())
+	suite.mockCmd.EXPECT().Stderr(&stderr)
 
 	err := l.Prepare(cfg)
 	suite.Require().Nil(err)
@@ -152,8 +152,8 @@ func (suite *LintTestSuite) TestPrepareWithNamespaceFlag() {
 		return suite.mockCmd
 	}
 
-	suite.mockCmd.EXPECT().Stdout(gomock.Any())
-	suite.mockCmd.EXPECT().Stderr(gomock.Any())
+	suite.mockCmd.EXPECT().Stdout(gomock.Any()).AnyTimes()
+	suite.mockCmd.EXPECT().Stderr(gomock.Any()).AnyTimes()
 
 	err := l.Prepare(cfg)
 	suite.Require().Nil(err)

--- a/internal/run/lint_test.go
+++ b/internal/run/lint_test.go
@@ -134,3 +134,30 @@ func (suite *LintTestSuite) TestPrepareWithDebugFlag() {
 	want := fmt.Sprintf("Generated command: '%s --debug lint ./scotland/top_40'\n", helmBin)
 	suite.Equal(want, stderr.String())
 }
+
+func (suite *LintTestSuite) TestPrepareWithNamespaceFlag() {
+	defer suite.ctrl.Finish()
+
+	cfg := Config{
+		Namespace: "table-service",
+	}
+
+	l := Lint{
+		Chart: "./wales/top_40",
+	}
+
+	actual := []string{}
+	command = func(path string, args ...string) cmd {
+		actual = args
+		return suite.mockCmd
+	}
+
+	suite.mockCmd.EXPECT().Stdout(gomock.Any())
+	suite.mockCmd.EXPECT().Stderr(gomock.Any())
+
+	err := l.Prepare(cfg)
+	suite.Require().Nil(err)
+
+	expected := []string{"--namespace", "table-service", "lint", "./wales/top_40"}
+	suite.Equal(expected, actual)
+}

--- a/internal/run/lint_test.go
+++ b/internal/run/lint_test.go
@@ -1,0 +1,58 @@
+package run
+
+import (
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type LintTestSuite struct {
+	suite.Suite
+	ctrl            *gomock.Controller
+	mockCmd         *Mockcmd
+	originalCommand func(string, ...string) cmd
+}
+
+func (suite *LintTestSuite) BeforeTest(_, _ string) {
+	suite.ctrl = gomock.NewController(suite.T())
+	suite.mockCmd = NewMockcmd(suite.ctrl)
+
+	suite.originalCommand = command
+	command = func(path string, args ...string) cmd { return suite.mockCmd }
+}
+
+func (suite *LintTestSuite) AfterTest(_, _ string) {
+	command = suite.originalCommand
+}
+
+func TestLintTestSuite(t *testing.T) {
+	suite.Run(t, new(LintTestSuite))
+}
+
+func (suite *LintTestSuite) TestPrepareAndExecute() {
+	defer suite.ctrl.Finish()
+
+	l := Lint{
+		Chart: "./epic/mychart",
+	}
+
+	command = func(path string, args ...string) cmd {
+		suite.Equal(helmBin, path)
+		suite.Equal([]string{"lint", "./epic/mychart"}, args)
+
+		return suite.mockCmd
+	}
+
+	suite.mockCmd.EXPECT().
+		Stdout(gomock.Any())
+	suite.mockCmd.EXPECT().
+		Stderr(gomock.Any())
+	suite.mockCmd.EXPECT().
+		Run().
+		Times(1)
+
+	cfg := Config{}
+	err := l.Prepare(cfg)
+	suite.Require().Nil(err)
+	l.Execute(cfg)
+}


### PR DESCRIPTION
Fixes #3.

I think this is code-complete, but I'm marking the PR a draft until I've had a chance to test it with a real drone job and helm chart.