### PR TITLE
Mention that EKS isn't currently supported [#5]

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ steps:
 drone-helm3 is largely backwards-compatible with drone-helm. There are some known differences:
 
 * `prefix` must be supplied via the `settings` block, not `environment`.
+* EKS is not supported. See [#5](https://github.com/pelotech/drone-helm3/issues/5) for more information.
 * Several settings no longer have any effect:
     * `purge` -- this is the default behavior in Helm 3
     * `recreate_pods`

--- a/assets/kubeconfig.tpl
+++ b/assets/kubeconfig.tpl
@@ -24,16 +24,4 @@ users:
   user:
 {{- if .Token }}
     token: {{ .Token }}
-{{- else if .EKSCluster }}
-    exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
-      command: aws-iam-authenticator
-      args:
-        - "token"
-        - "-i"
-        - "{{ .EKSCluster }}"
-    {{- if .EKSRoleARN }}
-        - "-r"
-        - "{{ .EKSRoleARN }}"
-    {{- end }}
 {{- end }}


### PR DESCRIPTION
We'd like to support it eventually, but the current state of affairs doesn't justify the effort.

Also removed some vestigial code that was copy-pasta from the kubeconfig in drone-helm.

Relates to #5 

Pre-merge checklist:

* [x] Code changes have tests (N/A)
* [x] Any changes to the config are documented in `docs/parameter_reference.md` (N/A)
* [x] Any new _required_ config is documented in `README.md` (N/A)
* [x] Any large changes have been verified by running a Drone job (N/A)
