### PR TITLE
Remove support for the prefix setting [#48]

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ steps:
 
 drone-helm3 is largely backwards-compatible with drone-helm. There are some known differences:
 
-* `prefix` must be supplied via the `settings` block, not `environment`.
+* The `prefix` setting is no longer supported. If you were relying on the `prefix` setting with `secrets: [...]`, you'll need to switch to the `from_secret` syntax.
 * Several settings no longer have any effect:
     * `purge` -- this is the default behavior in Helm 3
     * `recreate_pods`

--- a/docs/parameter_reference.md
+++ b/docs/parameter_reference.md
@@ -7,7 +7,6 @@
 | update_dependencies | boolean         | Calls `helm dependency update` before running the main command.|
 | helm_repos          | list\<string\>  | Calls `helm repo add $repo` before running the main command. Each string should be formatted as `repo_name=https://repo.url/`. |
 | namespace           | string          | Kubernetes namespace to use for this operation. |
-| prefix              | string          | Expect environment variables to be prefixed with the given string. For more details, see "Using the prefix setting" below. |
 | debug               | boolean         | Generate debug output within drone-helm3 and pass `--debug` to all helm commands. Use with care, since the debug output may include secrets. |
 
 ## Linting
@@ -62,7 +61,7 @@ Uninstallations are triggered when the `helm_command` setting is "uninstall" or 
 
 ### Where to put settings
 
-Any setting (with the exception of `prefix`; [see below](#user-content-using-the-prefix-setting)), can go in either the `settings` or `environment` section.
+Any setting can go in either the `settings` or `environment` section.
 
 ### Formatting non-string values
 
@@ -86,46 +85,4 @@ Note that **list members must not contain commas**. Both of the following are eq
 ```yaml
 values_files: [ "./over_9,000.yml" ]
 values_files: [ "./over_9", "000.yml" ]
-```
-
-### Using the `prefix` setting
-
-Because the prefix setting is meta-configuration, it has some inherent edge-cases. Here is what it does in the cases we've thought of:
-
-Unlike the other settings, it must be declared in the `settings` block, not `environment`:
-
-```yaml
-settings:
-  prefix: helm # drone-helm3 will look for environment variables called HELM_VARNAME
-environment:
-  prefix: armet # no effect
-```
-
-It does not apply to configuration in the `settings` block, only in `environment`:
-
-```yaml
-settings:
-  prefix: helm
-  helm_timeout: 5m # no effect
-environment:
-  helm_timeout: 2m # timeout will be 2 minutes
-```
-
-If the environment contains a variable in non-prefixed form, it will still be applied:
-
-```yaml
-settings:
-  prefix: helm
-environment:
-  timeout: 2m # timeout will be 2 minutes
-```
-
-If the environment contains both the prefixed and non-prefixed forms, drone-helm3 will use the prefixed form:
-
-```yaml
-settings:
-  prefix: helm
-environment:
-  timeout: 5m # overridden
-  helm_timeout: 2m # timeout will be 2 minutes
 ```

--- a/internal/helm/config.go
+++ b/internal/helm/config.go
@@ -12,14 +12,13 @@ var justNumbers = regexp.MustCompile(`^\d+$`)
 // The Config struct captures the `settings` and `environment` blocks in the application's drone
 // config. Configuration in drone's `settings` block arrives as uppercase env vars matching the
 // config key, prefixed with `PLUGIN_`. Config from the `environment` block is uppercased, but does
-// not have the `PLUGIN_` prefix. It may, however, be prefixed with the value in `$PLUGIN_PREFIX`.
+// not have the `PLUGIN_` prefix.
 type Config struct {
 	// Configuration for drone-helm itself
 	Command            string   `envconfig:"HELM_COMMAND"`           // Helm command to run
 	DroneEvent         string   `envconfig:"DRONE_BUILD_EVENT"`      // Drone event that invoked this plugin.
 	UpdateDependencies bool     `split_words:"true"`                 // Call `helm dependency update` before the main command
 	AddRepos           []string `envconfig:"HELM_REPOS"`             // Call `helm repo add` before the main command
-	Prefix             string   ``                                   // Prefix to use when looking up secret env vars
 	Debug              bool     ``                                   // Generate debug output and pass --debug to all helm commands
 	Values             string   ``                                   // Argument to pass to --set in applicable helm commands
 	StringValues       string   `split_words:"true"`                 // Argument to pass to --set-string in applicable helm commands
@@ -53,16 +52,8 @@ func NewConfig(stdout, stderr io.Writer) (*Config, error) {
 		return nil, err
 	}
 
-	prefix := cfg.Prefix
-
 	if err := envconfig.Process("", &cfg); err != nil {
 		return nil, err
-	}
-
-	if prefix != "" {
-		if err := envconfig.Process(cfg.Prefix, &cfg); err != nil {
-			return nil, err
-		}
 	}
 
 	if justNumbers.MatchString(cfg.Timeout) {

--- a/internal/helm/config_test.go
+++ b/internal/helm/config_test.go
@@ -19,7 +19,6 @@ func TestConfigTestSuite(t *testing.T) {
 }
 
 func (suite *ConfigTestSuite) TestNewConfigWithPluginPrefix() {
-	suite.unsetenv("PLUGIN_PREFIX")
 	suite.unsetenv("HELM_COMMAND")
 	suite.unsetenv("UPDATE_DEPENDENCIES")
 	suite.unsetenv("DEBUG")
@@ -37,7 +36,6 @@ func (suite *ConfigTestSuite) TestNewConfigWithPluginPrefix() {
 }
 
 func (suite *ConfigTestSuite) TestNewConfigWithNoPrefix() {
-	suite.unsetenv("PLUGIN_PREFIX")
 	suite.unsetenv("PLUGIN_HELM_COMMAND")
 	suite.unsetenv("PLUGIN_UPDATE_DEPENDENCIES")
 	suite.unsetenv("PLUGIN_DEBUG")
@@ -54,56 +52,14 @@ func (suite *ConfigTestSuite) TestNewConfigWithNoPrefix() {
 	suite.True(cfg.Debug)
 }
 
-func (suite *ConfigTestSuite) TestNewConfigWithConfigurablePrefix() {
-	suite.unsetenv("API_SERVER")
-	suite.unsetenv("PLUGIN_API_SERVER")
-
-	suite.setenv("PLUGIN_PREFIX", "prix_fixe")
-	suite.setenv("PRIX_FIXE_API_SERVER", "your waiter this evening")
-
-	cfg, err := NewConfig(&strings.Builder{}, &strings.Builder{})
-	suite.Require().NoError(err)
-
-	suite.Equal("prix_fixe", cfg.Prefix)
-	suite.Equal("your waiter this evening", cfg.APIServer)
-}
-
-func (suite *ConfigTestSuite) TestPrefixSettingDoesNotAffectPluginPrefix() {
-	suite.setenv("PLUGIN_PREFIX", "IXFREP")
-	suite.setenv("PLUGIN_HELM_COMMAND", "wake me up")
-	suite.setenv("IXFREP_PLUGIN_HELM_COMMAND", "send me to sleep inside")
-
-	cfg, err := NewConfig(&strings.Builder{}, &strings.Builder{})
-	suite.Require().NoError(err)
-
-	suite.Equal("wake me up", cfg.Command)
-}
-
-func (suite *ConfigTestSuite) TestPrefixSettingMustHavePluginPrefix() {
-	suite.unsetenv("PLUGIN_PREFIX")
-	suite.setenv("PREFIX", "refpix")
-	suite.setenv("HELM_COMMAND", "gimme more")
-	suite.setenv("REFPIX_HELM_COMMAND", "gimme less")
-
-	cfg, err := NewConfig(&strings.Builder{}, &strings.Builder{})
-	suite.Require().NoError(err)
-
-	suite.Equal("gimme more", cfg.Command)
-}
-
 func (suite *ConfigTestSuite) TestNewConfigWithConflictingVariables() {
 	suite.setenv("PLUGIN_HELM_COMMAND", "execute order 66")
 	suite.setenv("HELM_COMMAND", "defend the jedi") // values from the `environment` block override those from `settings`
-
-	suite.setenv("PLUGIN_PREFIX", "prod")
-	suite.setenv("TIMEOUT", "5m0s")
-	suite.setenv("PROD_TIMEOUT", "2m30s") // values from prefixed env vars override those from non-prefixed ones
 
 	cfg, err := NewConfig(&strings.Builder{}, &strings.Builder{})
 	suite.Require().NoError(err)
 
 	suite.Equal("defend the jedi", cfg.Command)
-	suite.Equal("2m30s", cfg.Timeout)
 }
 
 func (suite *ConfigTestSuite) TestNewConfigInfersNumbersAreSeconds() {


### PR DESCRIPTION
The setting isn't necessary with modern versions of Drone, and it creates a lot of edge-cases. The use-case doesn't justify the added complexity.

Fixes #48 

Pre-merge checklist:

* [x] Code changes have tests
* [x] Any changes to the config are documented in `docs/parameter_reference.md`
* [x] Any new _required_ config is documented in `README.md`
* [x] Any large changes have been verified by running a Drone job (n/a)
