### PR TITLE
Pass --strict to `helm lint` when so instructed

### DIFF
--- a/docs/parameter_reference.md
+++ b/docs/parameter_reference.md
@@ -19,6 +19,7 @@ Linting is only triggered when the `helm_command` setting is "lint".
 | values        | list\<string\> |          | Chart values to use as the `--set` argument to `helm lint`. |
 | string_values | list\<string\> |          | Chart values to use as the `--set-string` argument to `helm lint`. |
 | values_files  | list\<string\> |          | Values to use as `--values` arguments to `helm lint`. |
+| lint_strictly | boolean        |          | Pass `--strict` to `helm lint`, to turn warnings into errors. |
 
 ## Installation
 

--- a/internal/helm/config.go
+++ b/internal/helm/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	Chart              string   ``                                   // Chart argument to use in applicable helm commands
 	Release            string   ``                                   // Release argument to use in applicable helm commands
 	Force              bool     ``                                   // Pass --force to applicable helm commands
+	LintStrictly       bool     `split_words:"true"`                 // Pass --strict to `helm lint`
 
 	Stdout io.Writer `ignored:"true"`
 	Stderr io.Writer `ignored:"true"`

--- a/internal/helm/plan.go
+++ b/internal/helm/plan.go
@@ -133,7 +133,8 @@ var lint = func(cfg Config) []Step {
 		steps = append(steps, depUpdate(cfg)...)
 	}
 	steps = append(steps, &run.Lint{
-		Chart: cfg.Chart,
+		Chart:  cfg.Chart,
+		Strict: cfg.LintStrictly,
 	})
 
 	return steps

--- a/internal/helm/plan_test.go
+++ b/internal/helm/plan_test.go
@@ -299,14 +299,16 @@ func (suite *PlanTestSuite) TestAddRepos() {
 
 func (suite *PlanTestSuite) TestLint() {
 	cfg := Config{
-		Chart: "./flow",
+		Chart:        "./flow",
+		LintStrictly: true,
 	}
 
 	steps := lint(cfg)
 	suite.Equal(1, len(steps))
 
 	want := &run.Lint{
-		Chart: "./flow",
+		Chart:  "./flow",
+		Strict: true,
 	}
 	suite.Equal(want, steps[0])
 }

--- a/internal/run/lint.go
+++ b/internal/run/lint.go
@@ -6,8 +6,9 @@ import (
 
 // Lint is an execution step that calls `helm lint` when executed.
 type Lint struct {
-	Chart string
-	cmd   cmd
+	Chart  string
+	Strict bool
+	cmd    cmd
 }
 
 // Execute executes the `helm lint` command.
@@ -40,6 +41,9 @@ func (l *Lint) Prepare(cfg Config) error {
 	}
 	for _, vFile := range cfg.ValuesFiles {
 		args = append(args, "--values", vFile)
+	}
+	if l.Strict {
+		args = append(args, "--strict")
 	}
 
 	args = append(args, l.Chart)

--- a/internal/run/lint_test.go
+++ b/internal/run/lint_test.go
@@ -87,7 +87,8 @@ func (suite *LintTestSuite) TestPrepareWithLintFlags() {
 	}
 
 	l := Lint{
-		Chart: "./uk/top_40",
+		Chart:  "./uk/top_40",
+		Strict: true,
 	}
 
 	command = func(path string, args ...string) cmd {
@@ -97,6 +98,7 @@ func (suite *LintTestSuite) TestPrepareWithLintFlags() {
 			"--set-string", "version=2.0",
 			"--values", "/usr/local/underrides",
 			"--values", "/usr/local/overrides",
+			"--strict",
 			"./uk/top_40"}, args)
 
 		return suite.mockCmd


### PR DESCRIPTION
Fixes #28

Pre-merge checklist:

* [x] Code changes have tests
* [x] Any changes to the config are documented in `docs/parameter_reference.md`
* [x] Any new _required_ config is documented in `README.md`
* [x] Any large changes have been verified by running a Drone job
