### PR TITLE
Mention the external docs in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,8 @@
 Pre-merge checklist:
 
 * [ ] Code changes have tests
-* [ ] Any changes to the config are documented in `docs/parameter_reference.md`
-* [ ] Any new _required_ config is documented in `README.md`
+* [ ] Any config changes are documented:
+    * If the change touches _required_ config, there's a corresponding update to `README.md`
+    * There's a corresponding update to `docs/parameter_reference.md`
+    * There's a pull request to update [the parameter reference in drone-plugin-index](https://github.com/drone/drone-plugin-index/blob/master/content/pelotech/drone-helm3/index.md)
 * [ ] Any large changes have been verified by running a Drone job


### PR DESCRIPTION
I just opened a PR with a config change and forgot about the plugin-index docs...must be time to get around to this issue.

Fixes #63

Pre-merge checklist:

* [x] Code changes have tests
* [x] Any changes to the config are documented in `docs/parameter_reference.md`
* [x] Any new _required_ config is documented in `README.md`
* [x] Any large changes have been verified by running a Drone job
