### PR TITLE
More-idiomatic initialization of Steps

### DIFF
--- a/cmd/drone-helm/main.go
+++ b/cmd/drone-helm/main.go
@@ -5,11 +5,12 @@ import (
 	"os"
 
 	_ "github.com/joho/godotenv/autoload"
+	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/pelotech/drone-helm3/internal/helm"
 )
 
 func main() {
-	cfg, err := helm.NewConfig(os.Stdout, os.Stderr)
+	cfg, err := env.NewConfig(os.Stdout, os.Stderr)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err.Error())

--- a/internal/env/config.go
+++ b/internal/env/config.go
@@ -1,4 +1,4 @@
-package helm
+package env
 
 import (
 	"fmt"

--- a/internal/env/config_test.go
+++ b/internal/env/config_test.go
@@ -1,4 +1,4 @@
-package helm
+package env
 
 import (
 	"fmt"

--- a/internal/helm/mock_step_test.go
+++ b/internal/helm/mock_step_test.go
@@ -48,15 +48,15 @@ func (mr *MockStepMockRecorder) Prepare(arg0 interface{}) *gomock.Call {
 }
 
 // Execute mocks base method
-func (m *MockStep) Execute(arg0 run.Config) error {
+func (m *MockStep) Execute() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Execute", arg0)
+	ret := m.ctrl.Call(m, "Execute")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Execute indicates an expected call of Execute
-func (mr *MockStepMockRecorder) Execute(arg0 interface{}) *gomock.Call {
+func (mr *MockStepMockRecorder) Execute() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockStep)(nil).Execute), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockStep)(nil).Execute))
 }

--- a/internal/helm/mock_step_test.go
+++ b/internal/helm/mock_step_test.go
@@ -6,7 +6,6 @@ package helm
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	run "github.com/pelotech/drone-helm3/internal/run"
 	reflect "reflect"
 )
 
@@ -34,17 +33,17 @@ func (m *MockStep) EXPECT() *MockStepMockRecorder {
 }
 
 // Prepare mocks base method
-func (m *MockStep) Prepare(arg0 run.Config) error {
+func (m *MockStep) Prepare() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Prepare", arg0)
+	ret := m.ctrl.Call(m, "Prepare")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Prepare indicates an expected call of Prepare
-func (mr *MockStepMockRecorder) Prepare(arg0 interface{}) *gomock.Call {
+func (mr *MockStepMockRecorder) Prepare() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockStep)(nil).Prepare), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockStep)(nil).Prepare))
 }
 
 // Execute mocks base method

--- a/internal/helm/plan.go
+++ b/internal/helm/plan.go
@@ -98,21 +98,7 @@ var upgrade = func(cfg env.Config) []Step {
 	if cfg.UpdateDependencies {
 		steps = append(steps, depUpdate(cfg)...)
 	}
-	steps = append(steps, &run.Upgrade{
-		Chart:         cfg.Chart,
-		Release:       cfg.Release,
-		ChartVersion:  cfg.ChartVersion,
-		DryRun:        cfg.DryRun,
-		Wait:          cfg.Wait,
-		Values:        cfg.Values,
-		StringValues:  cfg.StringValues,
-		ValuesFiles:   cfg.ValuesFiles,
-		ReuseValues:   cfg.ReuseValues,
-		Timeout:       cfg.Timeout,
-		Force:         cfg.Force,
-		Atomic:        cfg.AtomicUpgrade,
-		CleanupOnFail: cfg.CleanupOnFail,
-	})
+	steps = append(steps, run.NewUpgrade(cfg))
 
 	return steps
 }
@@ -122,11 +108,7 @@ var uninstall = func(cfg env.Config) []Step {
 	if cfg.UpdateDependencies {
 		steps = append(steps, depUpdate(cfg)...)
 	}
-	steps = append(steps, &run.Uninstall{
-		Release:     cfg.Release,
-		DryRun:      cfg.DryRun,
-		KeepHistory: cfg.KeepHistory,
-	})
+	steps = append(steps, run.NewUninstall(cfg))
 
 	return steps
 }
@@ -136,53 +118,27 @@ var lint = func(cfg env.Config) []Step {
 	if cfg.UpdateDependencies {
 		steps = append(steps, depUpdate(cfg)...)
 	}
-	steps = append(steps, &run.Lint{
-		Chart:        cfg.Chart,
-		Values:       cfg.Values,
-		StringValues: cfg.StringValues,
-		ValuesFiles:  cfg.ValuesFiles,
-		Strict:       cfg.LintStrictly,
-	})
-
+	steps = append(steps, run.NewLint(cfg))
 	return steps
 }
 
 var help = func(cfg env.Config) []Step {
-	help := &run.Help{
-		HelmCommand: cfg.Command,
-	}
-	return []Step{help}
+	return []Step{run.NewHelp(cfg)}
 }
 
 func initKube(cfg env.Config) []Step {
-	return []Step{
-		&run.InitKube{
-			SkipTLSVerify:  cfg.SkipTLSVerify,
-			Certificate:    cfg.Certificate,
-			APIServer:      cfg.APIServer,
-			ServiceAccount: cfg.ServiceAccount,
-			Token:          cfg.KubeToken,
-			TemplateFile:   kubeConfigTemplate,
-			ConfigFile:     kubeConfigFile,
-		},
-	}
+	return []Step{run.NewInitKube(cfg, kubeConfigTemplate, kubeConfigFile)}
 }
 
 func addRepos(cfg env.Config) []Step {
 	steps := make([]Step, 0)
 	for _, repo := range cfg.AddRepos {
-		steps = append(steps, &run.AddRepo{
-			Repo: repo,
-		})
+		steps = append(steps, run.NewAddRepo(repo))
 	}
 
 	return steps
 }
 
 func depUpdate(cfg env.Config) []Step {
-	return []Step{
-		&run.DepUpdate{
-			Chart: cfg.Chart,
-		},
-	}
+	return []Step{run.NewDepUpdate(cfg)}
 }

--- a/internal/helm/plan.go
+++ b/internal/helm/plan.go
@@ -15,7 +15,7 @@ const (
 // A Step is one step in the plan.
 type Step interface {
 	Prepare(run.Config) error
-	Execute(run.Config) error
+	Execute() error
 }
 
 // A Plan is a series of steps to perform.
@@ -84,7 +84,7 @@ func (p *Plan) Execute() error {
 			fmt.Fprintf(p.cfg.Stderr, "calling %T.Execute (step %d)\n", step, i)
 		}
 
-		if err := step.Execute(p.runCfg); err != nil {
+		if err := step.Execute(); err != nil {
 			return fmt.Errorf("while executing %T step: %w", step, err)
 		}
 	}

--- a/internal/helm/plan_test.go
+++ b/internal/helm/plan_test.go
@@ -175,37 +175,6 @@ func (suite *PlanTestSuite) TestUninstallWithUpdateDependencies() {
 	suite.IsType(&run.DepUpdate{}, steps[1])
 }
 
-func (suite *PlanTestSuite) TestInitKube() {
-	cfg := env.Config{}
-
-	steps := initKube(cfg)
-	suite.Require().Equal(1, len(steps), "initKube should return one step")
-	suite.IsType(&run.InitKube{}, steps[0])
-}
-
-func (suite *PlanTestSuite) TestDepUpdate() {
-	cfg := env.Config{
-		UpdateDependencies: true,
-	}
-
-	steps := depUpdate(cfg)
-	suite.Require().Equal(1, len(steps), "depUpdate should return one step")
-	suite.IsType(&run.DepUpdate{}, steps[0])
-}
-
-func (suite *PlanTestSuite) TestAddRepos() {
-	cfg := env.Config{
-		AddRepos: []string{
-			"first=https://add.repos/one",
-			"second=https://add.repos/two",
-		},
-	}
-	steps := addRepos(cfg)
-	suite.Require().Equal(2, len(steps), "addRepos should add one step per repo")
-	suite.IsType(&run.AddRepo{}, steps[0])
-	suite.IsType(&run.AddRepo{}, steps[1])
-}
-
 func (suite *PlanTestSuite) TestLint() {
 	steps := lint(env.Config{})
 	suite.Require().Equal(1, len(steps))

--- a/internal/helm/plan_test.go
+++ b/internal/helm/plan_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/pelotech/drone-helm3/internal/run"
 )
 
@@ -25,14 +26,14 @@ func (suite *PlanTestSuite) TestNewPlan() {
 	stepTwo := NewMockStep(ctrl)
 
 	origHelp := help
-	help = func(cfg Config) []Step {
+	help = func(cfg env.Config) []Step {
 		return []Step{stepOne, stepTwo}
 	}
 	defer func() { help = origHelp }()
 
 	stdout := strings.Builder{}
 	stderr := strings.Builder{}
-	cfg := Config{
+	cfg := env.Config{
 		Command:   "help",
 		Debug:     false,
 		Namespace: "outer",
@@ -65,12 +66,12 @@ func (suite *PlanTestSuite) TestNewPlanAbortsOnError() {
 	stepTwo := NewMockStep(ctrl)
 
 	origHelp := help
-	help = func(cfg Config) []Step {
+	help = func(cfg env.Config) []Step {
 		return []Step{stepOne, stepTwo}
 	}
 	defer func() { help = origHelp }()
 
-	cfg := Config{
+	cfg := env.Config{
 		Command: "help",
 	}
 
@@ -129,7 +130,7 @@ func (suite *PlanTestSuite) TestExecuteAbortsOnError() {
 }
 
 func (suite *PlanTestSuite) TestUpgrade() {
-	cfg := Config{
+	cfg := env.Config{
 		ChartVersion:  "seventeen",
 		DryRun:        true,
 		Wait:          true,
@@ -172,7 +173,7 @@ func (suite *PlanTestSuite) TestUpgrade() {
 }
 
 func (suite *PlanTestSuite) TestUpgradeWithUpdateDependencies() {
-	cfg := Config{
+	cfg := env.Config{
 		UpdateDependencies: true,
 	}
 	steps := upgrade(cfg)
@@ -182,7 +183,7 @@ func (suite *PlanTestSuite) TestUpgradeWithUpdateDependencies() {
 }
 
 func (suite *PlanTestSuite) TestUpgradeWithAddRepos() {
-	cfg := Config{
+	cfg := env.Config{
 		AddRepos: []string{
 			"machine=https://github.com/harold_finch/themachine",
 		},
@@ -193,7 +194,7 @@ func (suite *PlanTestSuite) TestUpgradeWithAddRepos() {
 }
 
 func (suite *PlanTestSuite) TestUninstall() {
-	cfg := Config{
+	cfg := env.Config{
 		KubeToken:      "b2YgbXkgYWZmZWN0aW9u",
 		SkipTLSVerify:  true,
 		Certificate:    "cHJvY2xhaW1zIHdvbmRlcmZ1bCBmcmllbmRzaGlw",
@@ -233,7 +234,7 @@ func (suite *PlanTestSuite) TestUninstall() {
 }
 
 func (suite *PlanTestSuite) TestUninstallWithUpdateDependencies() {
-	cfg := Config{
+	cfg := env.Config{
 		UpdateDependencies: true,
 	}
 	steps := uninstall(cfg)
@@ -243,7 +244,7 @@ func (suite *PlanTestSuite) TestUninstallWithUpdateDependencies() {
 }
 
 func (suite *PlanTestSuite) TestInitKube() {
-	cfg := Config{
+	cfg := env.Config{
 		KubeToken:      "cXVlZXIgY2hhcmFjdGVyCg==",
 		SkipTLSVerify:  true,
 		Certificate:    "b2Ygd29rZW5lc3MK",
@@ -269,7 +270,7 @@ func (suite *PlanTestSuite) TestInitKube() {
 }
 
 func (suite *PlanTestSuite) TestDepUpdate() {
-	cfg := Config{
+	cfg := env.Config{
 		UpdateDependencies: true,
 		Chart:              "scatterplot",
 	}
@@ -286,7 +287,7 @@ func (suite *PlanTestSuite) TestDepUpdate() {
 }
 
 func (suite *PlanTestSuite) TestAddRepos() {
-	cfg := Config{
+	cfg := env.Config{
 		AddRepos: []string{
 			"first=https://add.repos/one",
 			"second=https://add.repos/two",
@@ -304,7 +305,7 @@ func (suite *PlanTestSuite) TestAddRepos() {
 }
 
 func (suite *PlanTestSuite) TestLint() {
-	cfg := Config{
+	cfg := env.Config{
 		Chart:        "./flow",
 		Values:       "steadfastness,forthrightness",
 		StringValues: "tensile_strength,flexibility",
@@ -326,7 +327,7 @@ func (suite *PlanTestSuite) TestLint() {
 }
 
 func (suite *PlanTestSuite) TestLintWithUpdateDependencies() {
-	cfg := Config{
+	cfg := env.Config{
 		UpdateDependencies: true,
 	}
 	steps := lint(cfg)
@@ -335,7 +336,7 @@ func (suite *PlanTestSuite) TestLintWithUpdateDependencies() {
 }
 
 func (suite *PlanTestSuite) TestLintWithAddRepos() {
-	cfg := Config{
+	cfg := env.Config{
 		AddRepos: []string{"friendczar=https://github.com/logan_pierce/friendczar"},
 	}
 	steps := lint(cfg)
@@ -344,7 +345,7 @@ func (suite *PlanTestSuite) TestLintWithAddRepos() {
 }
 
 func (suite *PlanTestSuite) TestDeterminePlanUpgradeCommand() {
-	cfg := Config{
+	cfg := env.Config{
 		Command: "upgrade",
 	}
 	stepsMaker := determineSteps(cfg)
@@ -352,7 +353,7 @@ func (suite *PlanTestSuite) TestDeterminePlanUpgradeCommand() {
 }
 
 func (suite *PlanTestSuite) TestDeterminePlanUpgradeFromDroneEvent() {
-	cfg := Config{}
+	cfg := env.Config{}
 
 	upgradeEvents := []string{"push", "tag", "deployment", "pull_request", "promote", "rollback"}
 	for _, event := range upgradeEvents {
@@ -363,7 +364,7 @@ func (suite *PlanTestSuite) TestDeterminePlanUpgradeFromDroneEvent() {
 }
 
 func (suite *PlanTestSuite) TestDeterminePlanUninstallCommand() {
-	cfg := Config{
+	cfg := env.Config{
 		Command: "uninstall",
 	}
 	stepsMaker := determineSteps(cfg)
@@ -372,7 +373,7 @@ func (suite *PlanTestSuite) TestDeterminePlanUninstallCommand() {
 
 // helm_command = delete is provided as an alias for backward-compatibility with drone-helm
 func (suite *PlanTestSuite) TestDeterminePlanDeleteCommand() {
-	cfg := Config{
+	cfg := env.Config{
 		Command: "delete",
 	}
 	stepsMaker := determineSteps(cfg)
@@ -380,7 +381,7 @@ func (suite *PlanTestSuite) TestDeterminePlanDeleteCommand() {
 }
 
 func (suite *PlanTestSuite) TestDeterminePlanDeleteFromDroneEvent() {
-	cfg := Config{
+	cfg := env.Config{
 		DroneEvent: "delete",
 	}
 	stepsMaker := determineSteps(cfg)
@@ -388,7 +389,7 @@ func (suite *PlanTestSuite) TestDeterminePlanDeleteFromDroneEvent() {
 }
 
 func (suite *PlanTestSuite) TestDeterminePlanLintCommand() {
-	cfg := Config{
+	cfg := env.Config{
 		Command: "lint",
 	}
 
@@ -397,7 +398,7 @@ func (suite *PlanTestSuite) TestDeterminePlanLintCommand() {
 }
 
 func (suite *PlanTestSuite) TestDeterminePlanHelpCommand() {
-	cfg := Config{
+	cfg := env.Config{
 		Command: "help",
 	}
 

--- a/internal/helm/plan_test.go
+++ b/internal/helm/plan_test.go
@@ -130,46 +130,10 @@ func (suite *PlanTestSuite) TestExecuteAbortsOnError() {
 }
 
 func (suite *PlanTestSuite) TestUpgrade() {
-	cfg := env.Config{
-		ChartVersion:  "seventeen",
-		DryRun:        true,
-		Wait:          true,
-		Values:        "steadfastness,forthrightness",
-		StringValues:  "tensile_strength,flexibility",
-		ValuesFiles:   []string{"/root/price_inventory.yml"},
-		ReuseValues:   true,
-		Timeout:       "go sit in the corner",
-		Chart:         "billboard_top_100",
-		Release:       "post_malone_circles",
-		Force:         true,
-		AtomicUpgrade: true,
-		CleanupOnFail: true,
-	}
-
-	steps := upgrade(cfg)
+	steps := upgrade(env.Config{})
 	suite.Require().Equal(2, len(steps), "upgrade should return 2 steps")
-	suite.Require().IsType(&run.InitKube{}, steps[0])
-
-	suite.Require().IsType(&run.Upgrade{}, steps[1])
-	upgrade, _ := steps[1].(*run.Upgrade)
-
-	expected := &run.Upgrade{
-		Chart:         cfg.Chart,
-		Release:       cfg.Release,
-		ChartVersion:  cfg.ChartVersion,
-		DryRun:        true,
-		Wait:          cfg.Wait,
-		Values:        "steadfastness,forthrightness",
-		StringValues:  "tensile_strength,flexibility",
-		ValuesFiles:   []string{"/root/price_inventory.yml"},
-		ReuseValues:   cfg.ReuseValues,
-		Timeout:       cfg.Timeout,
-		Force:         cfg.Force,
-		Atomic:        true,
-		CleanupOnFail: true,
-	}
-
-	suite.Equal(expected, upgrade)
+	suite.IsType(&run.InitKube{}, steps[0])
+	suite.IsType(&run.Upgrade{}, steps[1])
 }
 
 func (suite *PlanTestSuite) TestUpgradeWithUpdateDependencies() {
@@ -194,43 +158,11 @@ func (suite *PlanTestSuite) TestUpgradeWithAddRepos() {
 }
 
 func (suite *PlanTestSuite) TestUninstall() {
-	cfg := env.Config{
-		KubeToken:      "b2YgbXkgYWZmZWN0aW9u",
-		SkipTLSVerify:  true,
-		Certificate:    "cHJvY2xhaW1zIHdvbmRlcmZ1bCBmcmllbmRzaGlw",
-		APIServer:      "98.765.43.21",
-		ServiceAccount: "greathelm",
-		DryRun:         true,
-		Timeout:        "think about what you did",
-		Release:        "jetta_id_love_to_change_the_world",
-		KeepHistory:    true,
-	}
-
-	steps := uninstall(cfg)
+	steps := uninstall(env.Config{})
 	suite.Require().Equal(2, len(steps), "uninstall should return 2 steps")
 
-	suite.Require().IsType(&run.InitKube{}, steps[0])
-	init, _ := steps[0].(*run.InitKube)
-	var expected Step = &run.InitKube{
-		SkipTLSVerify:  true,
-		Certificate:    "cHJvY2xhaW1zIHdvbmRlcmZ1bCBmcmllbmRzaGlw",
-		APIServer:      "98.765.43.21",
-		ServiceAccount: "greathelm",
-		Token:          "b2YgbXkgYWZmZWN0aW9u",
-		TemplateFile:   kubeConfigTemplate,
-		ConfigFile:     kubeConfigFile,
-	}
-
-	suite.Equal(expected, init)
-
-	suite.Require().IsType(&run.Uninstall{}, steps[1])
-	actual, _ := steps[1].(*run.Uninstall)
-	expected = &run.Uninstall{
-		Release:     "jetta_id_love_to_change_the_world",
-		DryRun:      true,
-		KeepHistory: true,
-	}
-	suite.Equal(expected, actual)
+	suite.IsType(&run.InitKube{}, steps[0])
+	suite.IsType(&run.Uninstall{}, steps[1])
 }
 
 func (suite *PlanTestSuite) TestUninstallWithUpdateDependencies() {
@@ -244,46 +176,21 @@ func (suite *PlanTestSuite) TestUninstallWithUpdateDependencies() {
 }
 
 func (suite *PlanTestSuite) TestInitKube() {
-	cfg := env.Config{
-		KubeToken:      "cXVlZXIgY2hhcmFjdGVyCg==",
-		SkipTLSVerify:  true,
-		Certificate:    "b2Ygd29rZW5lc3MK",
-		APIServer:      "123.456.78.9",
-		ServiceAccount: "helmet",
-	}
+	cfg := env.Config{}
 
 	steps := initKube(cfg)
 	suite.Require().Equal(1, len(steps), "initKube should return one step")
-	suite.Require().IsType(&run.InitKube{}, steps[0])
-	init, _ := steps[0].(*run.InitKube)
-
-	expected := &run.InitKube{
-		SkipTLSVerify:  true,
-		Certificate:    "b2Ygd29rZW5lc3MK",
-		APIServer:      "123.456.78.9",
-		ServiceAccount: "helmet",
-		Token:          "cXVlZXIgY2hhcmFjdGVyCg==",
-		TemplateFile:   kubeConfigTemplate,
-		ConfigFile:     kubeConfigFile,
-	}
-	suite.Equal(expected, init)
+	suite.IsType(&run.InitKube{}, steps[0])
 }
 
 func (suite *PlanTestSuite) TestDepUpdate() {
 	cfg := env.Config{
 		UpdateDependencies: true,
-		Chart:              "scatterplot",
 	}
 
 	steps := depUpdate(cfg)
 	suite.Require().Equal(1, len(steps), "depUpdate should return one step")
-	suite.Require().IsType(&run.DepUpdate{}, steps[0])
-	update, _ := steps[0].(*run.DepUpdate)
-
-	expected := &run.DepUpdate{
-		Chart: "scatterplot",
-	}
-	suite.Equal(expected, update)
+	suite.IsType(&run.DepUpdate{}, steps[0])
 }
 
 func (suite *PlanTestSuite) TestAddRepos() {
@@ -295,35 +202,14 @@ func (suite *PlanTestSuite) TestAddRepos() {
 	}
 	steps := addRepos(cfg)
 	suite.Require().Equal(2, len(steps), "addRepos should add one step per repo")
-	suite.Require().IsType(&run.AddRepo{}, steps[0])
-	suite.Require().IsType(&run.AddRepo{}, steps[1])
-	first := steps[0].(*run.AddRepo)
-	second := steps[1].(*run.AddRepo)
-
-	suite.Equal(first.Repo, "first=https://add.repos/one")
-	suite.Equal(second.Repo, "second=https://add.repos/two")
+	suite.IsType(&run.AddRepo{}, steps[0])
+	suite.IsType(&run.AddRepo{}, steps[1])
 }
 
 func (suite *PlanTestSuite) TestLint() {
-	cfg := env.Config{
-		Chart:        "./flow",
-		Values:       "steadfastness,forthrightness",
-		StringValues: "tensile_strength,flexibility",
-		ValuesFiles:  []string{"/root/price_inventory.yml"},
-		LintStrictly: true,
-	}
-
-	steps := lint(cfg)
-	suite.Equal(1, len(steps))
-
-	want := &run.Lint{
-		Chart:        "./flow",
-		Values:       "steadfastness,forthrightness",
-		StringValues: "tensile_strength,flexibility",
-		ValuesFiles:  []string{"/root/price_inventory.yml"},
-		Strict:       true,
-	}
-	suite.Equal(want, steps[0])
+	steps := lint(env.Config{})
+	suite.Require().Equal(1, len(steps))
+	suite.IsType(&run.Lint{}, steps[0])
 }
 
 func (suite *PlanTestSuite) TestLintWithUpdateDependencies() {

--- a/internal/helm/plan_test.go
+++ b/internal/helm/plan_test.go
@@ -41,22 +41,14 @@ func (suite *PlanTestSuite) TestNewPlan() {
 		Stderr:    &stderr,
 	}
 
-	runCfg := run.Config{
-		Debug:     false,
-		Namespace: "outer",
-		Stdout:    &stdout,
-		Stderr:    &stderr,
-	}
-
 	stepOne.EXPECT().
-		Prepare(runCfg)
+		Prepare()
 	stepTwo.EXPECT().
-		Prepare(runCfg)
+		Prepare()
 
 	plan, err := NewPlan(cfg)
 	suite.Require().Nil(err)
 	suite.Equal(cfg, plan.cfg)
-	suite.Equal(runCfg, plan.runCfg)
 }
 
 func (suite *PlanTestSuite) TestNewPlanAbortsOnError() {
@@ -76,7 +68,7 @@ func (suite *PlanTestSuite) TestNewPlanAbortsOnError() {
 	}
 
 	stepOne.EXPECT().
-		Prepare(gomock.Any()).
+		Prepare().
 		Return(fmt.Errorf("I'm starry Dave, aye, cat blew that"))
 
 	_, err := NewPlan(cfg)
@@ -90,11 +82,8 @@ func (suite *PlanTestSuite) TestExecute() {
 	stepOne := NewMockStep(ctrl)
 	stepTwo := NewMockStep(ctrl)
 
-	runCfg := run.Config{}
-
 	plan := Plan{
-		steps:  []Step{stepOne, stepTwo},
-		runCfg: runCfg,
+		steps: []Step{stepOne, stepTwo},
 	}
 
 	stepOne.EXPECT().
@@ -113,11 +102,8 @@ func (suite *PlanTestSuite) TestExecuteAbortsOnError() {
 	stepOne := NewMockStep(ctrl)
 	stepTwo := NewMockStep(ctrl)
 
-	runCfg := run.Config{}
-
 	plan := Plan{
-		steps:  []Step{stepOne, stepTwo},
-		runCfg: runCfg,
+		steps: []Step{stepOne, stepTwo},
 	}
 
 	stepOne.EXPECT().

--- a/internal/helm/plan_test.go
+++ b/internal/helm/plan_test.go
@@ -98,10 +98,10 @@ func (suite *PlanTestSuite) TestExecute() {
 	}
 
 	stepOne.EXPECT().
-		Execute(runCfg).
+		Execute().
 		Times(1)
 	stepTwo.EXPECT().
-		Execute(runCfg).
+		Execute().
 		Times(1)
 
 	suite.NoError(plan.Execute())
@@ -121,7 +121,7 @@ func (suite *PlanTestSuite) TestExecuteAbortsOnError() {
 	}
 
 	stepOne.EXPECT().
-		Execute(runCfg).
+		Execute().
 		Times(1).
 		Return(fmt.Errorf("oh, he'll gnaw"))
 

--- a/internal/run/addrepo.go
+++ b/internal/run/addrepo.go
@@ -39,15 +39,7 @@ func (a *AddRepo) Prepare() error {
 	name := split[0]
 	url := split[1]
 
-	args := make([]string, 0)
-
-	if a.namespace != "" {
-		args = append(args, "--namespace", a.namespace)
-	}
-	if a.debug {
-		args = append(args, "--debug")
-	}
-
+	args := a.globalFlags()
 	args = append(args, "repo", "add", name, url)
 
 	a.cmd = command(helmBin, args...)

--- a/internal/run/addrepo.go
+++ b/internal/run/addrepo.go
@@ -11,6 +11,13 @@ type AddRepo struct {
 	cmd  cmd
 }
 
+// NewAddRepo creates an AddRepo for the given repo-spec. No validation is performed at this time.
+func NewAddRepo(repo string) *AddRepo {
+	return &AddRepo{
+		Repo: repo,
+	}
+}
+
 // Execute executes the `helm repo add` command.
 func (a *AddRepo) Execute(_ Config) error {
 	return a.cmd.Run()

--- a/internal/run/addrepo.go
+++ b/internal/run/addrepo.go
@@ -19,7 +19,7 @@ func NewAddRepo(repo string) *AddRepo {
 }
 
 // Execute executes the `helm repo add` command.
-func (a *AddRepo) Execute(_ Config) error {
+func (a *AddRepo) Execute() error {
 	return a.cmd.Run()
 }
 

--- a/internal/run/addrepo_test.go
+++ b/internal/run/addrepo_test.go
@@ -38,6 +38,12 @@ func TestAddRepoTestSuite(t *testing.T) {
 	suite.Run(t, new(AddRepoTestSuite))
 }
 
+func (suite *AddRepoTestSuite) TestNewAddRepo() {
+	repo := NewAddRepo("picompress=https://github.com/caleb_phipps/picompress")
+	suite.Require().NotNil(repo)
+	suite.Equal("picompress=https://github.com/caleb_phipps/picompress", repo.Repo)
+}
+
 func (suite *AddRepoTestSuite) TestPrepareAndExecute() {
 	stdout := strings.Builder{}
 	stderr := strings.Builder{}

--- a/internal/run/addrepo_test.go
+++ b/internal/run/addrepo_test.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"fmt"
 	"github.com/golang/mock/gomock"
 	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/stretchr/testify/suite"
@@ -96,43 +95,4 @@ func (suite *AddRepoTestSuite) TestPrepareWithEqualSignInURL() {
 	a := NewAddRepo(env.Config{}, "samaritan=https://github.com/arthur_claypool/samaritan?version=2.1")
 	suite.NoError(a.Prepare())
 	suite.Contains(suite.commandArgs, "https://github.com/arthur_claypool/samaritan?version=2.1")
-}
-
-func (suite *AddRepoTestSuite) TestNamespaceFlag() {
-	suite.mockCmd.EXPECT().Stdout(gomock.Any()).AnyTimes()
-	suite.mockCmd.EXPECT().Stderr(gomock.Any()).AnyTimes()
-	cfg := env.Config{
-		Namespace: "alliteration",
-	}
-	a := NewAddRepo(cfg, "edeath=https://github.com/theater_guy/e-death")
-
-	suite.NoError(a.Prepare())
-	suite.Equal(suite.commandPath, helmBin)
-	suite.Equal(suite.commandArgs, []string{"--namespace", "alliteration",
-		"repo", "add", "edeath", "https://github.com/theater_guy/e-death"})
-}
-
-func (suite *AddRepoTestSuite) TestDebugFlag() {
-	suite.mockCmd.EXPECT().Stdout(gomock.Any()).AnyTimes()
-	suite.mockCmd.EXPECT().Stderr(gomock.Any()).AnyTimes()
-
-	stderr := strings.Builder{}
-
-	command = func(path string, args ...string) cmd {
-		suite.mockCmd.EXPECT().
-			String().
-			Return(fmt.Sprintf("%s %s", path, strings.Join(args, " ")))
-
-		return suite.mockCmd
-	}
-
-	cfg := env.Config{
-		Debug:  true,
-		Stderr: &stderr,
-	}
-	a := NewAddRepo(cfg, "edeath=https://github.com/the_bug/e-death")
-
-	suite.Require().NoError(a.Prepare())
-	suite.Equal(fmt.Sprintf("Generated command: '%s --debug "+
-		"repo add edeath https://github.com/the_bug/e-death'\n", helmBin), stderr.String())
 }

--- a/internal/run/addrepo_test.go
+++ b/internal/run/addrepo_test.go
@@ -70,7 +70,7 @@ func (suite *AddRepoTestSuite) TestPrepareAndExecute() {
 		Run().
 		Times(1)
 
-	suite.Require().NoError(a.Execute(cfg))
+	suite.Require().NoError(a.Execute())
 
 }
 

--- a/internal/run/config.go
+++ b/internal/run/config.go
@@ -20,3 +20,14 @@ func newConfig(cfg env.Config) *config {
 		stderr:    cfg.Stderr,
 	}
 }
+
+func (cfg *config) globalFlags() []string {
+	flags := []string{}
+	if cfg.debug {
+		flags = append(flags, "--debug")
+	}
+	if cfg.namespace != "" {
+		flags = append(flags, "--namespace", cfg.namespace)
+	}
+	return flags
+}

--- a/internal/run/config.go
+++ b/internal/run/config.go
@@ -1,13 +1,22 @@
 package run
 
 import (
+	"github.com/pelotech/drone-helm3/internal/env"
 	"io"
 )
 
-// Config contains configuration applicable to all helm commands
-type Config struct {
-	Debug     bool
-	Namespace string
-	Stdout    io.Writer
-	Stderr    io.Writer
+type config struct {
+	debug     bool
+	namespace string
+	stdout    io.Writer
+	stderr    io.Writer
+}
+
+func newConfig(cfg env.Config) *config {
+	return &config{
+		debug:     cfg.Debug,
+		namespace: cfg.Namespace,
+		stdout:    cfg.Stdout,
+		stderr:    cfg.Stderr,
+	}
 }

--- a/internal/run/config_test.go
+++ b/internal/run/config_test.go
@@ -1,0 +1,35 @@
+package run
+
+import (
+	"github.com/pelotech/drone-helm3/internal/env"
+	"github.com/stretchr/testify/suite"
+	"strings"
+	"testing"
+)
+
+type ConfigTestSuite struct {
+	suite.Suite
+}
+
+func TestConfigTestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigTestSuite))
+}
+
+func (suite *ConfigTestSuite) TestNewConfig() {
+	stdout := &strings.Builder{}
+	stderr := &strings.Builder{}
+	envCfg := env.Config{
+		Namespace: "private",
+		Debug:     true,
+		Stdout:    stdout,
+		Stderr:    stderr,
+	}
+	cfg := newConfig(envCfg)
+	suite.Require().NotNil(cfg)
+	suite.Equal(&config{
+		namespace: "private",
+		debug:     true,
+		stdout:    stdout,
+		stderr:    stderr,
+	}, cfg)
+}

--- a/internal/run/config_test.go
+++ b/internal/run/config_test.go
@@ -33,3 +33,16 @@ func (suite *ConfigTestSuite) TestNewConfig() {
 		stderr:    stderr,
 	}, cfg)
 }
+
+func (suite *ConfigTestSuite) TestGlobalFlags() {
+	cfg := config{
+		debug:     true,
+		namespace: "public",
+	}
+	flags := cfg.globalFlags()
+	suite.Equal([]string{"--debug", "--namespace", "public"}, flags)
+
+	cfg = config{}
+	flags = cfg.globalFlags()
+	suite.Equal([]string{}, flags)
+}

--- a/internal/run/depupdate.go
+++ b/internal/run/depupdate.go
@@ -7,14 +7,16 @@ import (
 
 // DepUpdate is an execution step that calls `helm dependency update` when executed.
 type DepUpdate struct {
-	Chart string
+	*config
+	chart string
 	cmd   cmd
 }
 
 // NewDepUpdate creates a DepUpdate using fields from the given Config. No validation is performed at this time.
 func NewDepUpdate(cfg env.Config) *DepUpdate {
 	return &DepUpdate{
-		Chart: cfg.Chart,
+		config: newConfig(cfg),
+		chart:  cfg.Chart,
 	}
 }
 
@@ -24,28 +26,28 @@ func (d *DepUpdate) Execute() error {
 }
 
 // Prepare gets the DepUpdate ready to execute.
-func (d *DepUpdate) Prepare(cfg Config) error {
-	if d.Chart == "" {
+func (d *DepUpdate) Prepare() error {
+	if d.chart == "" {
 		return fmt.Errorf("chart is required")
 	}
 
 	args := make([]string, 0)
 
-	if cfg.Namespace != "" {
-		args = append(args, "--namespace", cfg.Namespace)
+	if d.namespace != "" {
+		args = append(args, "--namespace", d.namespace)
 	}
-	if cfg.Debug {
+	if d.debug {
 		args = append(args, "--debug")
 	}
 
-	args = append(args, "dependency", "update", d.Chart)
+	args = append(args, "dependency", "update", d.chart)
 
 	d.cmd = command(helmBin, args...)
-	d.cmd.Stdout(cfg.Stdout)
-	d.cmd.Stderr(cfg.Stderr)
+	d.cmd.Stdout(d.stdout)
+	d.cmd.Stderr(d.stderr)
 
-	if cfg.Debug {
-		fmt.Fprintf(cfg.Stderr, "Generated command: '%s'\n", d.cmd.String())
+	if d.debug {
+		fmt.Fprintf(d.stderr, "Generated command: '%s'\n", d.cmd.String())
 	}
 
 	return nil

--- a/internal/run/depupdate.go
+++ b/internal/run/depupdate.go
@@ -2,12 +2,20 @@ package run
 
 import (
 	"fmt"
+	"github.com/pelotech/drone-helm3/internal/env"
 )
 
 // DepUpdate is an execution step that calls `helm dependency update` when executed.
 type DepUpdate struct {
 	Chart string
 	cmd   cmd
+}
+
+// NewDepUpdate creates a DepUpdate using fields from the given Config. No validation is performed at this time.
+func NewDepUpdate(cfg env.Config) *DepUpdate {
+	return &DepUpdate{
+		Chart: cfg.Chart,
+	}
 }
 
 // Execute executes the `helm upgrade` command.

--- a/internal/run/depupdate.go
+++ b/internal/run/depupdate.go
@@ -19,7 +19,7 @@ func NewDepUpdate(cfg env.Config) *DepUpdate {
 }
 
 // Execute executes the `helm upgrade` command.
-func (d *DepUpdate) Execute(_ Config) error {
+func (d *DepUpdate) Execute() error {
 	return d.cmd.Run()
 }
 

--- a/internal/run/depupdate.go
+++ b/internal/run/depupdate.go
@@ -31,15 +31,7 @@ func (d *DepUpdate) Prepare() error {
 		return fmt.Errorf("chart is required")
 	}
 
-	args := make([]string, 0)
-
-	if d.namespace != "" {
-		args = append(args, "--namespace", d.namespace)
-	}
-	if d.debug {
-		args = append(args, "--debug")
-	}
-
+	args := d.globalFlags()
 	args = append(args, "dependency", "update", d.chart)
 
 	d.cmd = command(helmBin, args...)

--- a/internal/run/depupdate_test.go
+++ b/internal/run/depupdate_test.go
@@ -37,7 +37,7 @@ func (suite *DepUpdateTestSuite) TestNewDepUpdate() {
 		Chart: "scatterplot",
 	}
 	d := NewDepUpdate(cfg)
-	suite.Equal("scatterplot", d.Chart)
+	suite.Equal("scatterplot", d.chart)
 }
 
 func (suite *DepUpdateTestSuite) TestPrepareAndExecute() {
@@ -45,7 +45,8 @@ func (suite *DepUpdateTestSuite) TestPrepareAndExecute() {
 
 	stdout := strings.Builder{}
 	stderr := strings.Builder{}
-	cfg := Config{
+	cfg := env.Config{
+		Chart:  "your_top_songs_2019",
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}
@@ -64,19 +65,18 @@ func (suite *DepUpdateTestSuite) TestPrepareAndExecute() {
 		Run().
 		Times(1)
 
-	d := DepUpdate{
-		Chart: "your_top_songs_2019",
-	}
+	d := NewDepUpdate(cfg)
 
-	suite.Require().NoError(d.Prepare(cfg))
+	suite.Require().NoError(d.Prepare())
 	suite.NoError(d.Execute())
 }
 
 func (suite *DepUpdateTestSuite) TestPrepareNamespaceFlag() {
 	defer suite.ctrl.Finish()
 
-	cfg := Config{
+	cfg := env.Config{
 		Namespace: "spotify",
+		Chart:     "your_top_songs_2019",
 	}
 
 	command = func(path string, args ...string) cmd {
@@ -87,11 +87,9 @@ func (suite *DepUpdateTestSuite) TestPrepareNamespaceFlag() {
 	suite.mockCmd.EXPECT().Stdout(gomock.Any()).AnyTimes()
 	suite.mockCmd.EXPECT().Stderr(gomock.Any()).AnyTimes()
 
-	d := DepUpdate{
-		Chart: "your_top_songs_2019",
-	}
+	d := NewDepUpdate(cfg)
 
-	suite.Require().NoError(d.Prepare(cfg))
+	suite.Require().NoError(d.Prepare())
 }
 
 func (suite *DepUpdateTestSuite) TestPrepareDebugFlag() {
@@ -99,7 +97,8 @@ func (suite *DepUpdateTestSuite) TestPrepareDebugFlag() {
 
 	stdout := strings.Builder{}
 	stderr := strings.Builder{}
-	cfg := Config{
+	cfg := env.Config{
+		Chart:  "your_top_songs_2019",
 		Debug:  true,
 		Stdout: &stdout,
 		Stderr: &stderr,
@@ -115,11 +114,9 @@ func (suite *DepUpdateTestSuite) TestPrepareDebugFlag() {
 	suite.mockCmd.EXPECT().Stdout(gomock.Any()).AnyTimes()
 	suite.mockCmd.EXPECT().Stderr(gomock.Any()).AnyTimes()
 
-	d := DepUpdate{
-		Chart: "your_top_songs_2019",
-	}
+	d := NewDepUpdate(cfg)
 
-	suite.Require().NoError(d.Prepare(cfg))
+	suite.Require().NoError(d.Prepare())
 
 	want := fmt.Sprintf("Generated command: '%s --debug dependency update your_top_songs_2019'\n", helmBin)
 	suite.Equal(want, stderr.String())
@@ -127,11 +124,11 @@ func (suite *DepUpdateTestSuite) TestPrepareDebugFlag() {
 }
 
 func (suite *DepUpdateTestSuite) TestPrepareChartRequired() {
-	d := DepUpdate{}
+	d := NewDepUpdate(env.Config{})
 
 	suite.mockCmd.EXPECT().Stdout(gomock.Any()).AnyTimes()
 	suite.mockCmd.EXPECT().Stderr(gomock.Any()).AnyTimes()
 
-	err := d.Prepare(Config{})
+	err := d.Prepare()
 	suite.EqualError(err, "chart is required")
 }

--- a/internal/run/depupdate_test.go
+++ b/internal/run/depupdate_test.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"fmt"
 	"github.com/golang/mock/gomock"
 	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/stretchr/testify/suite"
@@ -69,58 +68,6 @@ func (suite *DepUpdateTestSuite) TestPrepareAndExecute() {
 
 	suite.Require().NoError(d.Prepare())
 	suite.NoError(d.Execute())
-}
-
-func (suite *DepUpdateTestSuite) TestPrepareNamespaceFlag() {
-	defer suite.ctrl.Finish()
-
-	cfg := env.Config{
-		Namespace: "spotify",
-		Chart:     "your_top_songs_2019",
-	}
-
-	command = func(path string, args ...string) cmd {
-		suite.Equal([]string{"--namespace", "spotify", "dependency", "update", "your_top_songs_2019"}, args)
-
-		return suite.mockCmd
-	}
-	suite.mockCmd.EXPECT().Stdout(gomock.Any()).AnyTimes()
-	suite.mockCmd.EXPECT().Stderr(gomock.Any()).AnyTimes()
-
-	d := NewDepUpdate(cfg)
-
-	suite.Require().NoError(d.Prepare())
-}
-
-func (suite *DepUpdateTestSuite) TestPrepareDebugFlag() {
-	defer suite.ctrl.Finish()
-
-	stdout := strings.Builder{}
-	stderr := strings.Builder{}
-	cfg := env.Config{
-		Chart:  "your_top_songs_2019",
-		Debug:  true,
-		Stdout: &stdout,
-		Stderr: &stderr,
-	}
-
-	command = func(path string, args ...string) cmd {
-		suite.mockCmd.EXPECT().
-			String().
-			Return(fmt.Sprintf("%s %s", path, strings.Join(args, " ")))
-
-		return suite.mockCmd
-	}
-	suite.mockCmd.EXPECT().Stdout(gomock.Any()).AnyTimes()
-	suite.mockCmd.EXPECT().Stderr(gomock.Any()).AnyTimes()
-
-	d := NewDepUpdate(cfg)
-
-	suite.Require().NoError(d.Prepare())
-
-	want := fmt.Sprintf("Generated command: '%s --debug dependency update your_top_songs_2019'\n", helmBin)
-	suite.Equal(want, stderr.String())
-	suite.Equal("", stdout.String())
 }
 
 func (suite *DepUpdateTestSuite) TestPrepareChartRequired() {

--- a/internal/run/depupdate_test.go
+++ b/internal/run/depupdate_test.go
@@ -69,7 +69,7 @@ func (suite *DepUpdateTestSuite) TestPrepareAndExecute() {
 	}
 
 	suite.Require().NoError(d.Prepare(cfg))
-	suite.NoError(d.Execute(cfg))
+	suite.NoError(d.Execute())
 }
 
 func (suite *DepUpdateTestSuite) TestPrepareNamespaceFlag() {

--- a/internal/run/depupdate_test.go
+++ b/internal/run/depupdate_test.go
@@ -3,6 +3,7 @@ package run
 import (
 	"fmt"
 	"github.com/golang/mock/gomock"
+	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/stretchr/testify/suite"
 	"strings"
 	"testing"
@@ -29,6 +30,14 @@ func (suite *DepUpdateTestSuite) AfterTest(_, _ string) {
 
 func TestDepUpdateTestSuite(t *testing.T) {
 	suite.Run(t, new(DepUpdateTestSuite))
+}
+
+func (suite *DepUpdateTestSuite) TestNewDepUpdate() {
+	cfg := env.Config{
+		Chart: "scatterplot",
+	}
+	d := NewDepUpdate(cfg)
+	suite.Equal("scatterplot", d.Chart)
 }
 
 func (suite *DepUpdateTestSuite) TestPrepareAndExecute() {

--- a/internal/run/help.go
+++ b/internal/run/help.go
@@ -34,10 +34,8 @@ func (h *Help) Execute() error {
 
 // Prepare gets the Help ready to execute.
 func (h *Help) Prepare() error {
-	args := []string{"help"}
-	if h.debug {
-		args = append([]string{"--debug"}, args...)
-	}
+	args := h.globalFlags()
+	args = append(args, "help")
 
 	h.cmd = command(helmBin, args...)
 	h.cmd.Stdout(h.stdout)

--- a/internal/run/help.go
+++ b/internal/run/help.go
@@ -19,7 +19,7 @@ func NewHelp(cfg env.Config) *Help {
 }
 
 // Execute executes the `helm help` command.
-func (h *Help) Execute(cfg Config) error {
+func (h *Help) Execute() error {
 	if err := h.cmd.Run(); err != nil {
 		return fmt.Errorf("while running '%s': %w", h.cmd.String(), err)
 	}

--- a/internal/run/help.go
+++ b/internal/run/help.go
@@ -7,14 +7,16 @@ import (
 
 // Help is a step in a helm Plan that calls `helm help`.
 type Help struct {
-	HelmCommand string
+	*config
+	helmCommand string
 	cmd         cmd
 }
 
 // NewHelp creates a Help using fields from the given Config. No validation is performed at this time.
 func NewHelp(cfg env.Config) *Help {
 	return &Help{
-		HelmCommand: cfg.Command,
+		config:      newConfig(cfg),
+		helmCommand: cfg.Command,
 	}
 }
 
@@ -24,25 +26,25 @@ func (h *Help) Execute() error {
 		return fmt.Errorf("while running '%s': %w", h.cmd.String(), err)
 	}
 
-	if h.HelmCommand == "help" {
+	if h.helmCommand == "help" {
 		return nil
 	}
-	return fmt.Errorf("unknown command '%s'", h.HelmCommand)
+	return fmt.Errorf("unknown command '%s'", h.helmCommand)
 }
 
 // Prepare gets the Help ready to execute.
-func (h *Help) Prepare(cfg Config) error {
+func (h *Help) Prepare() error {
 	args := []string{"help"}
-	if cfg.Debug {
+	if h.debug {
 		args = append([]string{"--debug"}, args...)
 	}
 
 	h.cmd = command(helmBin, args...)
-	h.cmd.Stdout(cfg.Stdout)
-	h.cmd.Stderr(cfg.Stderr)
+	h.cmd.Stdout(h.stdout)
+	h.cmd.Stderr(h.stderr)
 
-	if cfg.Debug {
-		fmt.Fprintf(cfg.Stderr, "Generated command: '%s'\n", h.cmd.String())
+	if h.debug {
+		fmt.Fprintf(h.stderr, "Generated command: '%s'\n", h.cmd.String())
 	}
 
 	return nil

--- a/internal/run/help.go
+++ b/internal/run/help.go
@@ -2,12 +2,20 @@ package run
 
 import (
 	"fmt"
+	"github.com/pelotech/drone-helm3/internal/env"
 )
 
 // Help is a step in a helm Plan that calls `helm help`.
 type Help struct {
 	HelmCommand string
 	cmd         cmd
+}
+
+// NewHelp creates a Help using fields from the given Config. No validation is performed at this time.
+func NewHelp(cfg env.Config) *Help {
+	return &Help{
+		HelmCommand: cfg.Command,
+	}
 }
 
 // Execute executes the `helm help` command.

--- a/internal/run/help_test.go
+++ b/internal/run/help_test.go
@@ -3,6 +3,7 @@ package run
 import (
 	"fmt"
 	"github.com/golang/mock/gomock"
+	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"strings"
@@ -15,6 +16,15 @@ type HelpTestSuite struct {
 
 func TestHelpTestSuite(t *testing.T) {
 	suite.Run(t, new(HelpTestSuite))
+}
+
+func (suite *HelpTestSuite) TestNewHelp() {
+	cfg := env.Config{
+		Command: "everybody dance NOW!!",
+	}
+	help := NewHelp(cfg)
+	suite.Require().NotNil(help)
+	suite.Equal("everybody dance NOW!!", help.HelmCommand)
 }
 
 func (suite *HelpTestSuite) TestPrepare() {

--- a/internal/run/help_test.go
+++ b/internal/run/help_test.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"fmt"
 	"github.com/golang/mock/gomock"
 	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/stretchr/testify/assert"
@@ -74,21 +73,4 @@ func (suite *HelpTestSuite) TestExecute() {
 
 	help.helmCommand = "get down on friday"
 	suite.EqualError(help.Execute(), "unknown command 'get down on friday'")
-}
-
-func (suite *HelpTestSuite) TestPrepareDebugFlag() {
-	stdout := strings.Builder{}
-	stderr := strings.Builder{}
-	cfg := env.Config{
-		Debug:  true,
-		Stdout: &stdout,
-		Stderr: &stderr,
-	}
-
-	help := NewHelp(cfg)
-	help.Prepare()
-
-	want := fmt.Sprintf("Generated command: '%s --debug help'\n", helmBin)
-	suite.Equal(want, stderr.String())
-	suite.Equal("", stdout.String())
 }

--- a/internal/run/help_test.go
+++ b/internal/run/help_test.go
@@ -73,15 +73,14 @@ func (suite *HelpTestSuite) TestExecute() {
 		Run().
 		Times(2)
 
-	cfg := Config{}
 	help := Help{
 		HelmCommand: "help",
 		cmd:         mCmd,
 	}
-	suite.NoError(help.Execute(cfg))
+	suite.NoError(help.Execute())
 
 	help.HelmCommand = "get down on friday"
-	suite.EqualError(help.Execute(cfg), "unknown command 'get down on friday'")
+	suite.EqualError(help.Execute(), "unknown command 'get down on friday'")
 }
 
 func (suite *HelpTestSuite) TestPrepareDebugFlag() {

--- a/internal/run/initkube.go
+++ b/internal/run/initkube.go
@@ -3,6 +3,7 @@ package run
 import (
 	"errors"
 	"fmt"
+	"github.com/pelotech/drone-helm3/internal/env"
 	"io"
 	"os"
 	"text/template"
@@ -30,6 +31,19 @@ type kubeValues struct {
 	Namespace      string
 	ServiceAccount string
 	Token          string
+}
+
+// NewInitKube creates a InitKube using the given Config and filepaths. No validation is performed at this time.
+func NewInitKube(cfg env.Config, templateFile, configFile string) *InitKube {
+	return &InitKube{
+		SkipTLSVerify:  cfg.SkipTLSVerify,
+		Certificate:    cfg.Certificate,
+		APIServer:      cfg.APIServer,
+		ServiceAccount: cfg.ServiceAccount,
+		Token:          cfg.KubeToken,
+		TemplateFile:   templateFile,
+		ConfigFile:     configFile,
+	}
 }
 
 // Execute generates a kubernetes config file from drone-helm3's template.

--- a/internal/run/initkube.go
+++ b/internal/run/initkube.go
@@ -11,10 +11,9 @@ import (
 
 // InitKube is a step in a helm Plan that initializes the kubernetes config file.
 type InitKube struct {
+	*config
 	templateFilename string
 	configFilename   string
-	debug            bool
-	stderr           io.Writer
 	template         *template.Template
 	configFile       io.WriteCloser
 	values           kubeValues
@@ -32,6 +31,7 @@ type kubeValues struct {
 // NewInitKube creates a InitKube using the given Config and filepaths. No validation is performed at this time.
 func NewInitKube(cfg env.Config, templateFile, configFile string) *InitKube {
 	return &InitKube{
+		config: newConfig(cfg),
 		values: kubeValues{
 			SkipTLSVerify:  cfg.SkipTLSVerify,
 			Certificate:    cfg.Certificate,
@@ -42,8 +42,6 @@ func NewInitKube(cfg env.Config, templateFile, configFile string) *InitKube {
 		},
 		templateFilename: templateFile,
 		configFilename:   configFile,
-		debug:            cfg.Debug,
-		stderr:           cfg.Stderr,
 	}
 }
 
@@ -57,7 +55,7 @@ func (i *InitKube) Execute() error {
 }
 
 // Prepare ensures all required configuration is present and that the config file is writable.
-func (i *InitKube) Prepare(cfg Config) error {
+func (i *InitKube) Prepare() error {
 	var err error
 
 	if i.values.APIServer == "" {

--- a/internal/run/initkube_test.go
+++ b/internal/run/initkube_test.go
@@ -6,6 +6,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 	"text/template"
 )
@@ -25,6 +26,8 @@ func (suite *InitKubeTestSuite) TestNewInitKube() {
 		APIServer:      "98.765.43.21",
 		ServiceAccount: "greathelm",
 		KubeToken:      "b2YgbXkgYWZmZWN0aW9u",
+		Stderr:         &strings.Builder{},
+		Debug:          true,
 	}
 
 	init := NewInitKube(cfg, "conf.tpl", "conf.yml")
@@ -38,6 +41,8 @@ func (suite *InitKubeTestSuite) TestNewInitKube() {
 		},
 		templateFilename: "conf.tpl",
 		configFilename:   "conf.yml",
+		debug:            true,
+		stderr:           cfg.Stderr,
 	}, init)
 }
 
@@ -70,7 +75,7 @@ namespace: {{ .Namespace }}
 	suite.IsType(&template.Template{}, init.template)
 	suite.NotNil(init.configFile)
 
-	err = init.Execute(cfg)
+	err = init.Execute()
 	suite.Require().Nil(err)
 
 	conf, err := ioutil.ReadFile(configFile.Name())
@@ -101,7 +106,7 @@ func (suite *InitKubeTestSuite) TestExecuteGeneratesConfig() {
 		},
 	}
 	suite.Require().NoError(init.Prepare(cfg))
-	suite.Require().NoError(init.Execute(cfg))
+	suite.Require().NoError(init.Execute())
 
 	contents, err := ioutil.ReadFile(configFile.Name())
 	suite.Require().NoError(err)
@@ -128,7 +133,7 @@ func (suite *InitKubeTestSuite) TestExecuteGeneratesConfig() {
 	init.values.Certificate = ""
 
 	suite.Require().NoError(init.Prepare(cfg))
-	suite.Require().NoError(init.Execute(cfg))
+	suite.Require().NoError(init.Execute())
 	contents, err = ioutil.ReadFile(configFile.Name())
 	suite.Require().NoError(err)
 	suite.Contains(string(contents), "insecure-skip-tls-verify: true")

--- a/internal/run/initkube_test.go
+++ b/internal/run/initkube_test.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/stretchr/testify/suite"
 	yaml "gopkg.in/yaml.v2"
 	"io/ioutil"
@@ -15,6 +16,27 @@ type InitKubeTestSuite struct {
 
 func TestInitKubeTestSuite(t *testing.T) {
 	suite.Run(t, new(InitKubeTestSuite))
+}
+
+func (suite *InitKubeTestSuite) TestNewInitKube() {
+	cfg := env.Config{
+		SkipTLSVerify:  true,
+		Certificate:    "cHJvY2xhaW1zIHdvbmRlcmZ1bCBmcmllbmRzaGlw",
+		APIServer:      "98.765.43.21",
+		ServiceAccount: "greathelm",
+		KubeToken:      "b2YgbXkgYWZmZWN0aW9u",
+	}
+
+	init := NewInitKube(cfg, "conf.tpl", "conf.yml")
+	suite.Equal(&InitKube{
+		SkipTLSVerify:  true,
+		Certificate:    "cHJvY2xhaW1zIHdvbmRlcmZ1bCBmcmllbmRzaGlw",
+		APIServer:      "98.765.43.21",
+		ServiceAccount: "greathelm",
+		Token:          "b2YgbXkgYWZmZWN0aW9u",
+		TemplateFile:   "conf.tpl",
+		ConfigFile:     "conf.yml",
+	}, init)
 }
 
 func (suite *InitKubeTestSuite) TestPrepareExecute() {

--- a/internal/run/lint.go
+++ b/internal/run/lint.go
@@ -7,22 +7,24 @@ import (
 
 // Lint is an execution step that calls `helm lint` when executed.
 type Lint struct {
-	Chart        string
-	Values       string
-	StringValues string
-	ValuesFiles  []string
-	Strict       bool
+	*config
+	chart        string
+	values       string
+	stringValues string
+	valuesFiles  []string
+	strict       bool
 	cmd          cmd
 }
 
 // NewLint creates a Lint using fields from the given Config. No validation is performed at this time.
 func NewLint(cfg env.Config) *Lint {
 	return &Lint{
-		Chart:        cfg.Chart,
-		Values:       cfg.Values,
-		StringValues: cfg.StringValues,
-		ValuesFiles:  cfg.ValuesFiles,
-		Strict:       cfg.LintStrictly,
+		config:       newConfig(cfg),
+		chart:        cfg.Chart,
+		values:       cfg.Values,
+		stringValues: cfg.StringValues,
+		valuesFiles:  cfg.ValuesFiles,
+		strict:       cfg.LintStrictly,
 	}
 }
 
@@ -32,43 +34,43 @@ func (l *Lint) Execute() error {
 }
 
 // Prepare gets the Lint ready to execute.
-func (l *Lint) Prepare(cfg Config) error {
-	if l.Chart == "" {
+func (l *Lint) Prepare() error {
+	if l.chart == "" {
 		return fmt.Errorf("chart is required")
 	}
 
 	args := make([]string, 0)
 
-	if cfg.Namespace != "" {
-		args = append(args, "--namespace", cfg.Namespace)
+	if l.namespace != "" {
+		args = append(args, "--namespace", l.namespace)
 	}
-	if cfg.Debug {
+	if l.debug {
 		args = append(args, "--debug")
 	}
 
 	args = append(args, "lint")
 
-	if l.Values != "" {
-		args = append(args, "--set", l.Values)
+	if l.values != "" {
+		args = append(args, "--set", l.values)
 	}
-	if l.StringValues != "" {
-		args = append(args, "--set-string", l.StringValues)
+	if l.stringValues != "" {
+		args = append(args, "--set-string", l.stringValues)
 	}
-	for _, vFile := range l.ValuesFiles {
+	for _, vFile := range l.valuesFiles {
 		args = append(args, "--values", vFile)
 	}
-	if l.Strict {
+	if l.strict {
 		args = append(args, "--strict")
 	}
 
-	args = append(args, l.Chart)
+	args = append(args, l.chart)
 
 	l.cmd = command(helmBin, args...)
-	l.cmd.Stdout(cfg.Stdout)
-	l.cmd.Stderr(cfg.Stderr)
+	l.cmd.Stdout(l.stdout)
+	l.cmd.Stderr(l.stderr)
 
-	if cfg.Debug {
-		fmt.Fprintf(cfg.Stderr, "Generated command: '%s'\n", l.cmd.String())
+	if l.debug {
+		fmt.Fprintf(l.stderr, "Generated command: '%s'\n", l.cmd.String())
 	}
 
 	return nil

--- a/internal/run/lint.go
+++ b/internal/run/lint.go
@@ -39,15 +39,7 @@ func (l *Lint) Prepare() error {
 		return fmt.Errorf("chart is required")
 	}
 
-	args := make([]string, 0)
-
-	if l.namespace != "" {
-		args = append(args, "--namespace", l.namespace)
-	}
-	if l.debug {
-		args = append(args, "--debug")
-	}
-
+	args := l.globalFlags()
 	args = append(args, "lint")
 
 	if l.values != "" {

--- a/internal/run/lint.go
+++ b/internal/run/lint.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"fmt"
+	"github.com/pelotech/drone-helm3/internal/env"
 )
 
 // Lint is an execution step that calls `helm lint` when executed.
@@ -12,6 +13,17 @@ type Lint struct {
 	ValuesFiles  []string
 	Strict       bool
 	cmd          cmd
+}
+
+// NewLint creates a Lint using fields from the given Config. No validation is performed at this time.
+func NewLint(cfg env.Config) *Lint {
+	return &Lint{
+		Chart:        cfg.Chart,
+		Values:       cfg.Values,
+		StringValues: cfg.StringValues,
+		ValuesFiles:  cfg.ValuesFiles,
+		Strict:       cfg.LintStrictly,
+	}
 }
 
 // Execute executes the `helm lint` command.

--- a/internal/run/lint.go
+++ b/internal/run/lint.go
@@ -27,7 +27,7 @@ func NewLint(cfg env.Config) *Lint {
 }
 
 // Execute executes the `helm lint` command.
-func (l *Lint) Execute(_ Config) error {
+func (l *Lint) Execute() error {
 	return l.cmd.Run()
 }
 

--- a/internal/run/lint_test.go
+++ b/internal/run/lint_test.go
@@ -3,6 +3,7 @@ package run
 import (
 	"fmt"
 	"github.com/golang/mock/gomock"
+	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/stretchr/testify/suite"
 	"strings"
 	"testing"
@@ -29,6 +30,25 @@ func (suite *LintTestSuite) AfterTest(_, _ string) {
 
 func TestLintTestSuite(t *testing.T) {
 	suite.Run(t, new(LintTestSuite))
+}
+
+func (suite *LintTestSuite) TestNewLint() {
+	cfg := env.Config{
+		Chart:        "./flow",
+		Values:       "steadfastness,forthrightness",
+		StringValues: "tensile_strength,flexibility",
+		ValuesFiles:  []string{"/root/price_inventory.yml"},
+		LintStrictly: true,
+	}
+	lint := NewLint(cfg)
+	suite.Require().NotNil(lint)
+	suite.Equal(&Lint{
+		Chart:        "./flow",
+		Values:       "steadfastness,forthrightness",
+		StringValues: "tensile_strength,flexibility",
+		ValuesFiles:  []string{"/root/price_inventory.yml"},
+		Strict:       true,
+	}, lint)
 }
 
 func (suite *LintTestSuite) TestPrepareAndExecute() {

--- a/internal/run/lint_test.go
+++ b/internal/run/lint_test.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"fmt"
 	"github.com/golang/mock/gomock"
 	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/stretchr/testify/suite"
@@ -125,59 +124,4 @@ func (suite *LintTestSuite) TestPrepareWithLintFlags() {
 
 	err := l.Prepare()
 	suite.Require().Nil(err)
-}
-
-func (suite *LintTestSuite) TestPrepareWithDebugFlag() {
-	defer suite.ctrl.Finish()
-
-	stderr := strings.Builder{}
-
-	cfg := env.Config{
-		Debug:  true,
-		Stderr: &stderr,
-		Chart:  "./scotland/top_40",
-	}
-	l := NewLint(cfg)
-
-	command = func(path string, args ...string) cmd {
-		suite.mockCmd.EXPECT().
-			String().
-			Return(fmt.Sprintf("%s %s", path, strings.Join(args, " ")))
-
-		return suite.mockCmd
-	}
-
-	suite.mockCmd.EXPECT().Stdout(gomock.Any())
-	suite.mockCmd.EXPECT().Stderr(&stderr)
-
-	err := l.Prepare()
-	suite.Require().Nil(err)
-
-	want := fmt.Sprintf("Generated command: '%s --debug lint ./scotland/top_40'\n", helmBin)
-	suite.Equal(want, stderr.String())
-}
-
-func (suite *LintTestSuite) TestPrepareWithNamespaceFlag() {
-	defer suite.ctrl.Finish()
-
-	cfg := env.Config{
-		Namespace: "table-service",
-		Chart:     "./wales/top_40",
-	}
-	l := NewLint(cfg)
-
-	actual := []string{}
-	command = func(path string, args ...string) cmd {
-		actual = args
-		return suite.mockCmd
-	}
-
-	suite.mockCmd.EXPECT().Stdout(gomock.Any()).AnyTimes()
-	suite.mockCmd.EXPECT().Stderr(gomock.Any()).AnyTimes()
-
-	err := l.Prepare()
-	suite.Require().Nil(err)
-
-	expected := []string{"--namespace", "table-service", "lint", "./wales/top_40"}
-	suite.Equal(expected, actual)
 }

--- a/internal/run/lint_test.go
+++ b/internal/run/lint_test.go
@@ -82,7 +82,7 @@ func (suite *LintTestSuite) TestPrepareAndExecute() {
 
 	err := l.Prepare(cfg)
 	suite.Require().Nil(err)
-	l.Execute(cfg)
+	l.Execute()
 }
 
 func (suite *LintTestSuite) TestPrepareRequiresChart() {

--- a/internal/run/uninstall.go
+++ b/internal/run/uninstall.go
@@ -35,15 +35,7 @@ func (u *Uninstall) Prepare() error {
 		return fmt.Errorf("release is required")
 	}
 
-	args := make([]string, 0)
-
-	if u.namespace != "" {
-		args = append(args, "--namespace", u.namespace)
-	}
-	if u.debug {
-		args = append(args, "--debug")
-	}
-
+	args := u.globalFlags()
 	args = append(args, "uninstall")
 
 	if u.dryRun {

--- a/internal/run/uninstall.go
+++ b/internal/run/uninstall.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"fmt"
+	"github.com/pelotech/drone-helm3/internal/env"
 )
 
 // Uninstall is an execution step that calls `helm uninstall` when executed.
@@ -10,6 +11,15 @@ type Uninstall struct {
 	DryRun      bool
 	KeepHistory bool
 	cmd         cmd
+}
+
+// NewUninstall creates an Uninstall using fields from the given Config. No validation is performed at this time.
+func NewUninstall(cfg env.Config) *Uninstall {
+	return &Uninstall{
+		Release:     cfg.Release,
+		DryRun:      cfg.DryRun,
+		KeepHistory: cfg.KeepHistory,
+	}
 }
 
 // Execute executes the `helm uninstall` command.

--- a/internal/run/uninstall.go
+++ b/internal/run/uninstall.go
@@ -23,7 +23,7 @@ func NewUninstall(cfg env.Config) *Uninstall {
 }
 
 // Execute executes the `helm uninstall` command.
-func (u *Uninstall) Execute(_ Config) error {
+func (u *Uninstall) Execute() error {
 	return u.cmd.Run()
 }
 

--- a/internal/run/uninstall_test.go
+++ b/internal/run/uninstall_test.go
@@ -78,7 +78,7 @@ func (suite *UninstallTestSuite) TestPrepareAndExecute() {
 	expected := []string{"uninstall", "zayde_wølf_king"}
 	suite.Equal(expected, actual)
 
-	u.Execute(cfg)
+	u.Execute()
 }
 
 func (suite *UninstallTestSuite) TestPrepareDryRunFlag() {

--- a/internal/run/uninstall_test.go
+++ b/internal/run/uninstall_test.go
@@ -1,11 +1,9 @@
 package run
 
 import (
-	"fmt"
 	"github.com/golang/mock/gomock"
 	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/stretchr/testify/suite"
-	"strings"
 	"testing"
 )
 
@@ -108,46 +106,6 @@ func (suite *UninstallTestSuite) TestPrepareKeepHistoryFlag() {
 	suite.NoError(u.Prepare())
 	expected := []string{"uninstall", "--keep-history", "perturbator_sentient"}
 	suite.Equal(expected, suite.actualArgs)
-}
-
-func (suite *UninstallTestSuite) TestPrepareNamespaceFlag() {
-	cfg := env.Config{
-		Release:   "carly_simon_run_away_with_me",
-		Namespace: "emotion",
-	}
-	u := NewUninstall(cfg)
-
-	suite.mockCmd.EXPECT().Stdout(gomock.Any()).AnyTimes()
-	suite.mockCmd.EXPECT().Stderr(gomock.Any()).AnyTimes()
-
-	suite.NoError(u.Prepare())
-	expected := []string{"--namespace", "emotion", "uninstall", "carly_simon_run_away_with_me"}
-	suite.Equal(expected, suite.actualArgs)
-}
-
-func (suite *UninstallTestSuite) TestPrepareDebugFlag() {
-	stderr := strings.Builder{}
-	cfg := env.Config{
-		Release: "just_a_band_huff_and_puff",
-		Debug:   true,
-		Stderr:  &stderr,
-	}
-	u := NewUninstall(cfg)
-
-	command = func(path string, args ...string) cmd {
-		suite.mockCmd.EXPECT().
-			String().
-			Return(fmt.Sprintf("%s %s", path, strings.Join(args, " ")))
-
-		return suite.mockCmd
-	}
-
-	suite.mockCmd.EXPECT().Stdout(gomock.Any()).AnyTimes()
-	suite.mockCmd.EXPECT().Stderr(&stderr).AnyTimes()
-
-	suite.NoError(u.Prepare())
-	suite.Equal(fmt.Sprintf("Generated command: '%s --debug "+
-		"uninstall just_a_band_huff_and_puff'\n", helmBin), stderr.String())
 }
 
 func (suite *UninstallTestSuite) TestPrepareRequiresRelease() {

--- a/internal/run/uninstall_test.go
+++ b/internal/run/uninstall_test.go
@@ -3,6 +3,7 @@ package run
 import (
 	"fmt"
 	"github.com/golang/mock/gomock"
+	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/stretchr/testify/suite"
 	"strings"
 	"testing"
@@ -33,6 +34,20 @@ func (suite *UninstallTestSuite) AfterTest(_, _ string) {
 
 func TestUninstallTestSuite(t *testing.T) {
 	suite.Run(t, new(UninstallTestSuite))
+}
+
+func (suite *UninstallTestSuite) TestNewUninstall() {
+	cfg := env.Config{
+		DryRun:      true,
+		Release:     "jetta_id_love_to_change_the_world",
+		KeepHistory: true,
+	}
+	u := NewUninstall(cfg)
+	suite.Equal(&Uninstall{
+		Release:     "jetta_id_love_to_change_the_world",
+		DryRun:      true,
+		KeepHistory: true,
+	}, u)
 }
 
 func (suite *UninstallTestSuite) TestPrepareAndExecute() {

--- a/internal/run/upgrade.go
+++ b/internal/run/upgrade.go
@@ -45,7 +45,7 @@ func NewUpgrade(cfg env.Config) *Upgrade {
 }
 
 // Execute executes the `helm upgrade` command.
-func (u *Upgrade) Execute(_ Config) error {
+func (u *Upgrade) Execute() error {
 	return u.cmd.Run()
 }
 

--- a/internal/run/upgrade.go
+++ b/internal/run/upgrade.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"fmt"
+	"github.com/pelotech/drone-helm3/internal/env"
 )
 
 // Upgrade is an execution step that calls `helm upgrade` when executed.
@@ -22,6 +23,25 @@ type Upgrade struct {
 	CleanupOnFail bool
 
 	cmd cmd
+}
+
+// NewUpgrade creates an Upgrade using fields from the given Config. No validation is performed at this time.
+func NewUpgrade(cfg env.Config) *Upgrade {
+	return &Upgrade{
+		Chart:         cfg.Chart,
+		Release:       cfg.Release,
+		ChartVersion:  cfg.ChartVersion,
+		DryRun:        cfg.DryRun,
+		Wait:          cfg.Wait,
+		Values:        cfg.Values,
+		StringValues:  cfg.StringValues,
+		ValuesFiles:   cfg.ValuesFiles,
+		ReuseValues:   cfg.ReuseValues,
+		Timeout:       cfg.Timeout,
+		Force:         cfg.Force,
+		Atomic:        cfg.AtomicUpgrade,
+		CleanupOnFail: cfg.CleanupOnFail,
+	}
 }
 
 // Execute executes the `helm upgrade` command.

--- a/internal/run/upgrade.go
+++ b/internal/run/upgrade.go
@@ -60,15 +60,7 @@ func (u *Upgrade) Prepare() error {
 		return fmt.Errorf("release is required")
 	}
 
-	args := make([]string, 0)
-
-	if u.namespace != "" {
-		args = append(args, "--namespace", u.namespace)
-	}
-	if u.debug {
-		args = append(args, "--debug")
-	}
-
+	args := u.globalFlags()
 	args = append(args, "upgrade", "--install")
 
 	if u.chartVersion != "" {

--- a/internal/run/upgrade_test.go
+++ b/internal/run/upgrade_test.go
@@ -3,6 +3,7 @@ package run
 import (
 	"fmt"
 	"github.com/golang/mock/gomock"
+	"github.com/pelotech/drone-helm3/internal/env"
 	"github.com/stretchr/testify/suite"
 	"strings"
 	"testing"
@@ -29,6 +30,41 @@ func (suite *UpgradeTestSuite) AfterTest(_, _ string) {
 
 func TestUpgradeTestSuite(t *testing.T) {
 	suite.Run(t, new(UpgradeTestSuite))
+}
+
+func (suite *UpgradeTestSuite) TestNewUpgrade() {
+	cfg := env.Config{
+		ChartVersion:  "seventeen",
+		DryRun:        true,
+		Wait:          true,
+		Values:        "steadfastness,forthrightness",
+		StringValues:  "tensile_strength,flexibility",
+		ValuesFiles:   []string{"/root/price_inventory.yml"},
+		ReuseValues:   true,
+		Timeout:       "go sit in the corner",
+		Chart:         "billboard_top_100",
+		Release:       "post_malone_circles",
+		Force:         true,
+		AtomicUpgrade: true,
+		CleanupOnFail: true,
+	}
+
+	up := NewUpgrade(cfg)
+	suite.Equal(&Upgrade{
+		Chart:         cfg.Chart,
+		Release:       cfg.Release,
+		ChartVersion:  cfg.ChartVersion,
+		DryRun:        true,
+		Wait:          cfg.Wait,
+		Values:        "steadfastness,forthrightness",
+		StringValues:  "tensile_strength,flexibility",
+		ValuesFiles:   []string{"/root/price_inventory.yml"},
+		ReuseValues:   cfg.ReuseValues,
+		Timeout:       cfg.Timeout,
+		Force:         cfg.Force,
+		Atomic:        true,
+		CleanupOnFail: true,
+	}, up)
 }
 
 func (suite *UpgradeTestSuite) TestPrepareAndExecute() {

--- a/internal/run/upgrade_test.go
+++ b/internal/run/upgrade_test.go
@@ -93,7 +93,7 @@ func (suite *UpgradeTestSuite) TestPrepareAndExecute() {
 	cfg := Config{}
 	err := u.Prepare(cfg)
 	suite.Require().Nil(err)
-	u.Execute(cfg)
+	u.Execute()
 }
 
 func (suite *UpgradeTestSuite) TestPrepareNamespaceFlag() {


### PR DESCRIPTION
For #67 

The main thrust of this change is to use the go convention of `NewTHING` functions to initialize the structs in `internal/run` instead of constructing struct literals in `plan.go`. Unfortunately, it'ss a big honkin' diff that touches almost every source file in the repo. It's probably easier to read in two chunks:

1. [Initialize the various Steps with `NewSTEPNAME` functions](https://github.com/pelotech/drone-helm3/compare/master...88bb808)
1. [Firm up the separation-of-concerns boundary between the `run` and `helm` packages](https://github.com/pelotech/drone-helm3/compare/88bb808...79532e7)

Alternatively, starting with the diffs for `internal/helm/plan.go` and `internal/run/depupdate.go` should give you a reasonably-clear overview of what's happened--`plan.go` shows how the `run` package's public interface has changed, while `depupdate.go` is a fairly short file that demonstrates the changes to the Steps.

Pre-merge checklist:

* [x] Code changes have tests
* [x] Any config changes are documented: (n/a)
    * If the change touches _required_ config, there's a corresponding update to `README.md`
    * There's a corresponding update to `docs/parameter_reference.md`
    * There's a pull request to update [the parameter reference in drone-plugin-index](https://github.com/drone/drone-plugin-index/blob/master/content/pelotech/drone-helm3/index.md)
* [x] Any large changes have been verified by running a Drone job
