### PR TITLE
Interpolate environment variables into cfg.Values and cfg.StringValues

### DIFF
--- a/docs/parameter_reference.md
+++ b/docs/parameter_reference.md
@@ -95,6 +95,26 @@ values_files: [ "./over_9,000.yml" ]
 values_files: [ "./over_9", "000.yml" ]
 ```
 
+### Interpolating secrets into the `values` and `string_values` settings
+
+If you want to send secrets to your charts, you can use syntax similar to shell variable interpolation--either `$VARNAME` or `$${VARNAME}`. The double dollar-sign is necessary when using curly brackets; using curly brackets with a single dollar-sign will trigger Drone's string substitution (which can't use arbitrary environment variables). If an environment variable is not set, it will be treated as if it were set to the empty string.
+
+```yaml
+environment:
+  DB_PASSWORD:
+    from_secret: db_password
+  SESSION_KEY:
+    from_secret: session_key
+settings:
+  values:
+    - db_password=$DB_PASSWORD    # db_password will be set to the contents of the db_password secret
+    - db_pass=$DB_PASS            # db_pass will be set to "" since $DB_PASS is not set
+    - session_key=$${SESSION_KEY} # session_key will be set to the contents of the session_key secret
+    - sess_key=${SESSION_KEY}     # sess_key will be set to "" by Drone's variable substitution
+```
+
+Variables intended for interpolation must be set in the `environment` section, not `settings`.
+
 ### Backward-compatibility aliases
 
 Some settings have alternate names, for backward-compatibility with drone-helm. We recommend using the canonical name unless you require the backward-compatible form.

--- a/internal/env/config.go
+++ b/internal/env/config.go
@@ -89,11 +89,11 @@ func NewConfig(stdout, stderr io.Writer) (*Config, error) {
 		cfg.Timeout = fmt.Sprintf("%ss", cfg.Timeout)
 	}
 
+	cfg.loadValuesSecrets()
+
 	if cfg.Debug && cfg.Stderr != nil {
 		cfg.logDebug()
 	}
-
-	cfg.loadValuesSecrets()
 
 	cfg.deprecationWarn()
 
@@ -108,9 +108,6 @@ func (cfg *Config) loadValuesSecrets() {
 		varName = sigils.ReplaceAllString(varName, "")
 
 		if value, ok := os.LookupEnv(varName); ok {
-			if cfg.Debug {
-				fmt.Fprintf(cfg.Stderr, "Replaced $%s with value in environment\n", varName)
-			}
 			return value
 		}
 
@@ -120,13 +117,7 @@ func (cfg *Config) loadValuesSecrets() {
 		return ""
 	}
 
-	if cfg.Debug {
-		fmt.Fprintf(cfg.Stderr, "Replacing environment variable references in Values\n")
-	}
 	cfg.Values = findVar.ReplaceAllStringFunc(cfg.Values, replacer)
-	if cfg.Debug {
-		fmt.Fprintf(cfg.Stderr, "Replacing environment variable references in StringValues\n")
-	}
 	cfg.StringValues = findVar.ReplaceAllStringFunc(cfg.StringValues, replacer)
 }
 

--- a/internal/env/config.go
+++ b/internal/env/config.go
@@ -108,13 +108,25 @@ func (cfg *Config) loadValuesSecrets() {
 		varName = sigils.ReplaceAllString(varName, "")
 
 		if value, ok := os.LookupEnv(varName); ok {
+			if cfg.Debug {
+				fmt.Fprintf(cfg.Stderr, "Replaced $%s with value in environment\n", varName)
+			}
 			return value
 		}
 
+		if cfg.Debug {
+			fmt.Fprintf(cfg.Stderr, "$%s not present in environment, replaced with \"\"\n", varName)
+		}
 		return ""
 	}
 
+	if cfg.Debug {
+		fmt.Fprintf(cfg.Stderr, "Replacing environment variable references in Values\n")
+	}
 	cfg.Values = findVar.ReplaceAllStringFunc(cfg.Values, replacer)
+	if cfg.Debug {
+		fmt.Fprintf(cfg.Stderr, "Replacing environment variable references in StringValues\n")
+	}
 	cfg.StringValues = findVar.ReplaceAllStringFunc(cfg.StringValues, replacer)
 }
 

--- a/internal/env/config_test.go
+++ b/internal/env/config_test.go
@@ -183,6 +183,21 @@ func (suite *ConfigTestSuite) TestLogDebugCensorsKubeToken() {
 	suite.Equal(kubeToken, cfg.KubeToken) // The actual config value should be left unchanged
 }
 
+func (suite *ConfigTestSuite) TestNewConfigWithValuesSecrets() {
+	suite.unsetenv("VALUES")
+	suite.unsetenv("STRING_VALUES")
+	suite.setenv("SECRET_FIRE", "Eru_Ilúvatar")
+	suite.setenv("SECRET_RINGS", "1")
+	suite.setenv("PLUGIN_VALUES", "fire=$SECRET_FIRE,water=${SECRET_WATER}")
+	suite.setenv("PLUGIN_STRING_VALUES", "rings=${SECRET_RINGS}")
+
+	cfg, err := NewConfig(&strings.Builder{}, &strings.Builder{})
+	suite.Require().NoError(err)
+
+	suite.Equal("fire=Eru_Ilúvatar,water=", cfg.Values)
+	suite.Equal("rings=1", cfg.StringValues)
+}
+
 func (suite *ConfigTestSuite) setenv(key, val string) {
 	orig, ok := os.LookupEnv(key)
 	if ok {

--- a/internal/env/config_test.go
+++ b/internal/env/config_test.go
@@ -186,6 +186,7 @@ func (suite *ConfigTestSuite) TestLogDebugCensorsKubeToken() {
 func (suite *ConfigTestSuite) TestNewConfigWithValuesSecrets() {
 	suite.unsetenv("VALUES")
 	suite.unsetenv("STRING_VALUES")
+	suite.unsetenv("SECRET_WATER")
 	suite.setenv("SECRET_FIRE", "Eru_Ilúvatar")
 	suite.setenv("SECRET_RINGS", "1")
 	suite.setenv("PLUGIN_VALUES", "fire=$SECRET_FIRE,water=${SECRET_WATER}")
@@ -200,6 +201,7 @@ func (suite *ConfigTestSuite) TestNewConfigWithValuesSecrets() {
 
 func (suite *ConfigTestSuite) TestValuesSecretsWithDebugLogging() {
 	suite.unsetenv("VALUES")
+	suite.unsetenv("SECRET_WATER")
 	suite.setenv("SECRET_FIRE", "Eru_Ilúvatar")
 	suite.setenv("PLUGIN_DEBUG", "true")
 	suite.setenv("PLUGIN_STRING_VALUES", "fire=$SECRET_FIRE")

--- a/internal/env/config_test.go
+++ b/internal/env/config_test.go
@@ -208,15 +208,8 @@ func (suite *ConfigTestSuite) TestValuesSecretsWithDebugLogging() {
 	_, err := NewConfig(&strings.Builder{}, &stderr)
 	suite.Require().NoError(err)
 
-	// Make a good-faith effort to avoid putting secrets in the log output, but still mention they were found
-	suite.Contains(stderr.String(), "Values:fire=$SECRET_FIRE,water=$SECRET_WATER")
-	suite.Contains(stderr.String(), `
-Replacing environment variable references in Values
-Replaced $SECRET_FIRE with value in environment
-$SECRET_WATER not present in environment, replaced with ""
-Replacing environment variable references in StringValues
-Replaced $SECRET_FIRE with value in environment
-`)
+	suite.Contains(stderr.String(), "Values:fire=Eru_Ilúvatar,water=")
+	suite.Contains(stderr.String(), `$SECRET_WATER not present in environment, replaced with ""`)
 }
 
 func (suite *ConfigTestSuite) setenv(key, val string) {


### PR DESCRIPTION
Fixes #34 

Pre-merge checklist:

* [x] Code changes have tests
* [x] Any config changes are documented:
    * If the change touches _required_ config, there's a corresponding update to `README.md`
    * There's a corresponding update to `docs/parameter_reference.md`
    * There's a pull request to update [the parameter reference in drone-plugin-index](https://github.com/drone/drone-plugin-index/blob/master/content/pelotech/drone-helm3/index.md)
* [x] Any large changes have been verified by running a Drone job