### PR TITLE
Support skipping kubeconfig creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+*.swp
 
 .idea
 

--- a/docs/parameter_reference.md
+++ b/docs/parameter_reference.md
@@ -31,10 +31,11 @@ Installations are triggered when the `mode` setting is "upgrade." They can also 
 |------------------------|----------------|----------|------------------------|---------|
 | chart                  | string         | yes      |                        | The chart to use for this installation. |
 | release                | string         | yes      |                        | The release name for helm to use. |
-| kube_api_server        | string         | yes      | api_server             | API endpoint for the Kubernetes cluster. |
-| kube_token             | string         | yes      | kubernetes_token       | Token for authenticating to Kubernetes. |
-| kube_service_account   | string         |          | service_account        | Service account for authenticating to Kubernetes. Default is `helm`. |
-| kube_certificate       | string         |          | kubernetes_certificate | Base64 encoded TLS certificate used by the Kubernetes cluster's certificate authority. |
+| skip_kubeconfig        | boolean        |          |                        | Whether to skip kubeconfig file creation. |
+| kube_api_server        | string         | yes      | api_server             | API endpoint for the Kubernetes cluster. This is ignored if `skip_kubeconfig` is `true`. |
+| kube_token             | string         | yes      | kubernetes_token       | Token for authenticating to Kubernetes. This is ignored if `skip_kubeconfig` is `true`. |
+| kube_service_account   | string         |          | service_account        | Service account for authenticating to Kubernetes. Default is `helm`. This is ignored if `skip_kubeconfig` is `true`. |
+| kube_certificate       | string         |          | kubernetes_certificate | Base64 encoded TLS certificate used by the Kubernetes cluster's certificate authority. This is ignored if `skip_kubeconfig` is `true`. |
 | chart_version          | string         |          |                        | Specific chart version to install. |
 | dry_run                | boolean        |          |                        | Pass `--dry-run` to `helm upgrade`. |
 | dependencies_action    | string         |          |                        | Calls `helm dependency build` OR `helm dependency update` before running the main command. Possible values: `build`, `update`. |
@@ -47,7 +48,7 @@ Installations are triggered when the `mode` setting is "upgrade." They can also 
 | string_values          | list\<string\> |          |                        | Chart values to use as the `--set-string` argument to `helm upgrade`. |
 | values_files           | list\<string\> |          |                        | Values to use as `--values` arguments to `helm upgrade`. |
 | reuse_values           | boolean        |          |                        | Reuse the values from a previous release. |
-| skip_tls_verify        | boolean        |          |                        | Connect to the Kubernetes cluster without checking for a valid TLS certificate. Not recommended in production. |
+| skip_tls_verify        | boolean        |          |                        | Connect to the Kubernetes cluster without checking for a valid TLS certificate. Not recommended in production. This is ignored if `skip_kubeconfig` is `true`. |
 
 ## Uninstallation
 
@@ -56,14 +57,15 @@ Uninstallations are triggered when the `mode` setting is "uninstall" or "delete.
 | Param name             | Type     | Required | Alias                  | Purpose |
 |------------------------|----------|----------|------------------------|---------|
 | release                | string   | yes      |                        | The release name for helm to use. |
-| kube_api_server        | string   | yes      | api_server             | API endpoint for the Kubernetes cluster. |
-| kube_token             | string   | yes      | kubernetes_token       | Token for authenticating to Kubernetes. |
-| kube_service_account   | string   |          | service_account        | Service account for authenticating to Kubernetes. Default is `helm`. |
-| kube_certificate       | string   |          | kubernetes_certificate | Base64 encoded TLS certificate used by the Kubernetes cluster's certificate authority. |
+| skip_kubeconfig        | boolean  |          |                        | Whether to skip kubeconfig file creation. |
+| kube_api_server        | string   | yes      | api_server             | API endpoint for the Kubernetes cluster. This is ignored if `skip_kubeconfig` is `true`. |
+| kube_token             | string   | yes      | kubernetes_token       | Token for authenticating to Kubernetes. This is ignored if `skip_kubeconfig` is `true`. |
+| kube_service_account   | string   |          | service_account        | Service account for authenticating to Kubernetes. Default is `helm`. This is ignored if `skip_kubeconfig` is `true`. |
+| kube_certificate       | string   |          | kubernetes_certificate | Base64 encoded TLS certificate used by the Kubernetes cluster's certificate authority. This is ignored if `skip_kubeconfig` is `true`. |
 | keep_history           | boolean  |          |                        | Pass `--keep-history` to `helm uninstall`, to retain the release history. |
 | dry_run                | boolean  |          |                        | Pass `--dry-run` to `helm uninstall`. |
 | timeout                | duration |          |                        | Timeout for any *individual* Kubernetes operation. The uninstallation's full runtime may exceed this duration. |
-| skip_tls_verify        | boolean  |          |                        | Connect to the Kubernetes cluster without checking for a valid TLS certificate. Not recommended in production. |
+| skip_tls_verify        | boolean  |          |                        | Connect to the Kubernetes cluster without checking for a valid TLS certificate. Not recommended in production. This is ignored if `skip_kubeconfig` is `true`. |
 | chart                  | string   |          |                        | Required when the global `update_dependencies` parameter is true. No effect otherwise. |
 
 ### Where to put settings

--- a/internal/env/config.go
+++ b/internal/env/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	StringValues       string   `split_words:"true"`                 // Argument to pass to --set-string in applicable helm commands
 	ValuesFiles        []string `split_words:"true"`                 // Arguments to pass to --values in applicable helm commands
 	Namespace          string   ``                                   // Kubernetes namespace for all helm commands
+	KubeInitSkip       bool     `envconfig:"kube_init_skip"`         // Skip kubeconfig creation
 	KubeToken          string   `split_words:"true"`                 // Kubernetes authentication token to put in .kube/config
 	SkipTLSVerify      bool     `envconfig:"skip_tls_verify"`        // Put insecure-skip-tls-verify in .kube/config
 	Certificate        string   `envconfig:"kube_certificate"`       // The Kubernetes cluster CA's self-signed certificate (must be base64-encoded)

--- a/internal/env/config.go
+++ b/internal/env/config.go
@@ -33,8 +33,8 @@ type Config struct {
 	StringValues       string   `split_words:"true"`                 // Argument to pass to --set-string in applicable helm commands
 	ValuesFiles        []string `split_words:"true"`                 // Arguments to pass to --values in applicable helm commands
 	Namespace          string   ``                                   // Kubernetes namespace for all helm commands
-	KubeInitSkip       bool     `envconfig:"kube_init_skip"`         // Skip kubeconfig creation
 	KubeToken          string   `split_words:"true"`                 // Kubernetes authentication token to put in .kube/config
+	SkipKubeconfig     bool     `envconfig:"skip_kubeconfig"`        // Skip kubeconfig creation
 	SkipTLSVerify      bool     `envconfig:"skip_tls_verify"`        // Put insecure-skip-tls-verify in .kube/config
 	Certificate        string   `envconfig:"kube_certificate"`       // The Kubernetes cluster CA's self-signed certificate (must be base64-encoded)
 	APIServer          string   `envconfig:"kube_api_server"`        // The Kubernetes cluster's API endpoint
@@ -86,6 +86,12 @@ func NewConfig(stdout, stderr io.Writer) (*Config, error) {
 
 	if err := envconfig.Process("", &cfg); err != nil {
 		return nil, err
+	}
+
+	if cfg.SkipKubeconfig {
+		if cfg.KubeToken != "" || cfg.Certificate != "" || cfg.APIServer != "" || cfg.ServiceAccount != "" || cfg.SkipTLSVerify {
+			fmt.Fprintf(cfg.Stderr, "Warning: skip_kubeconfig is set. The following kubeconfig-related settings will be ignored: kube_config, kube_certificate, kube_api_server, kube_service_account, skip_tls_verify.")
+		}
 	}
 
 	if justNumbers.MatchString(cfg.Timeout) {

--- a/internal/helm/plan.go
+++ b/internal/helm/plan.go
@@ -92,7 +92,9 @@ func (p *Plan) Execute() error {
 
 var upgrade = func(cfg env.Config) []Step {
 	var steps []Step
-	steps = append(steps, run.NewInitKube(cfg, kubeConfigTemplate, kubeConfigFile))
+	if !cfg.KubeInitSkip {
+		steps = append(steps, run.NewInitKube(cfg, kubeConfigTemplate, kubeConfigFile))
+	}
 	for _, repo := range cfg.AddRepos {
 		steps = append(steps, run.NewAddRepo(cfg, repo))
 	}
@@ -112,7 +114,9 @@ var upgrade = func(cfg env.Config) []Step {
 
 var uninstall = func(cfg env.Config) []Step {
 	var steps []Step
-	steps = append(steps, run.NewInitKube(cfg, kubeConfigTemplate, kubeConfigFile))
+	if !cfg.KubeInitSkip {
+		steps = append(steps, run.NewInitKube(cfg, kubeConfigTemplate, kubeConfigFile))
+	}
 	if cfg.UpdateDependencies {
 		steps = append(steps, run.NewDepUpdate(cfg))
 	}

--- a/internal/helm/plan.go
+++ b/internal/helm/plan.go
@@ -92,7 +92,7 @@ func (p *Plan) Execute() error {
 
 var upgrade = func(cfg env.Config) []Step {
 	var steps []Step
-	if !cfg.KubeInitSkip {
+	if !cfg.SkipKubeconfig {
 		steps = append(steps, run.NewInitKube(cfg, kubeConfigTemplate, kubeConfigFile))
 	}
 	for _, repo := range cfg.AddRepos {
@@ -114,7 +114,7 @@ var upgrade = func(cfg env.Config) []Step {
 
 var uninstall = func(cfg env.Config) []Step {
 	var steps []Step
-	if !cfg.KubeInitSkip {
+	if !cfg.SkipKubeconfig {
 		steps = append(steps, run.NewInitKube(cfg, kubeConfigTemplate, kubeConfigFile))
 	}
 	if cfg.UpdateDependencies {

--- a/internal/helm/plan_test.go
+++ b/internal/helm/plan_test.go
@@ -122,8 +122,8 @@ func (suite *PlanTestSuite) TestUpgrade() {
 	suite.IsType(&run.Upgrade{}, steps[1])
 }
 
-func (suite *PlanTestSuite) TestUpgradeWithKubeInitSkip() {
-	steps := upgrade(env.Config{KubeInitSkip: true})
+func (suite *PlanTestSuite) TestUpgradeWithSkipKubeconfig() {
+	steps := upgrade(env.Config{SkipKubeconfig: true})
 	suite.Require().Equal(1, len(steps), "upgrade should return 1 step")
 	suite.IsType(&run.Upgrade{}, steps[0])
 }

--- a/internal/helm/plan_test.go
+++ b/internal/helm/plan_test.go
@@ -122,6 +122,12 @@ func (suite *PlanTestSuite) TestUpgrade() {
 	suite.IsType(&run.Upgrade{}, steps[1])
 }
 
+func (suite *PlanTestSuite) TestUpgradeWithKubeInitSkip() {
+	steps := upgrade(env.Config{KubeInitSkip: true})
+	suite.Require().Equal(1, len(steps), "upgrade should return 1 step")
+	suite.IsType(&run.Upgrade{}, steps[0])
+}
+
 func (suite *PlanTestSuite) TestUpgradeWithUpdateDependencies() {
 	cfg := env.Config{
 		UpdateDependencies: true,


### PR DESCRIPTION
This PR add a new param ~`kube_init_skip`~ `skip_kubeconfig` to skip the creation of kubeconfig file.
This is useful in case we already have the kubeconfig file somewhere and just want to reuse it. For example:

```yaml
---
kind: pipeline
type: kubernetes
name: default

volumes:
- name: kubeconfig
  temp: {}

- name: create_kubeconfig
  image: some/plugin
  volumes:
  - name: kubeconfig
    path: /root/.kube

- name: deploy_production
  image: pelotech/drone-helm3
  settings:
    helm_command: upgrade
    chart: ./
    release: my-project
    skip_kubeconfig: true
  volumes:
  - name: kubeconfig
    path: /root/.kube
```

PR to update the official document is here: https://github.com/drone/drone-plugin-index/pull/286

Pre-merge checklist:

* [x] Code changes have tests
* [x] Any config changes are documented:
    * If the change touches _required_ config, there's a corresponding update to `README.md`
    * There's a corresponding update to `docs/parameter_reference.md`
    * There's a pull request to update [the parameter reference in drone-plugin-index](https://github.com/drone/drone-plugin-index/blob/master/content/pelotech/drone-helm3/index.md)
* [x] Any large changes have been verified by running a Drone job
