### PR TITLE
add skip-crds flag support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine/helm:3.2.4
+FROM alpine/helm:3.6.2
 MAINTAINER Erin Call <erin@liffft.com>
 
 COPY build/drone-helm /bin/drone-helm

--- a/docs/parameter_reference.md
+++ b/docs/parameter_reference.md
@@ -50,6 +50,7 @@ Installations are triggered when the `mode` setting is "upgrade." They can also 
 | reuse_values           | boolean        |          |                        | Reuse the values from a previous release. |
 | skip_tls_verify        | boolean        |          |                        | Connect to the Kubernetes cluster without checking for a valid TLS certificate. Not recommended in production. This is ignored if `skip_kubeconfig` is `true`. |
 | create_namespace       | boolean        |          |                        | Pass --create-namespace to `helm upgrade`. |
+| skip_crds              | boolean        |          |                        | Pass --skip-crds to `helm upgrade`. |
 
 ## Uninstallation
 

--- a/internal/env/config.go
+++ b/internal/env/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	AtomicUpgrade      bool     `split_words:"true"`                 // Pass --atomic to `helm upgrade`
 	CleanupOnFail      bool     `envconfig:"cleanup_failed_upgrade"` // Pass --cleanup-on-fail to `helm upgrade`
 	LintStrictly       bool     `split_words:"true"`                 // Pass --strict to `helm lint`
+	SkipCrds           bool     `split_words:"true"`                 // Pass --skip-crds to `helm upgrade`
 
 	Stdout io.Writer `ignored:"true"`
 	Stderr io.Writer `ignored:"true"`

--- a/internal/run/upgrade.go
+++ b/internal/run/upgrade.go
@@ -24,6 +24,7 @@ type Upgrade struct {
 	cleanupOnFail   bool
 	certs           *repoCerts
 	createNamespace bool
+	skipCrds        bool
 
 	cmd cmd
 }
@@ -47,6 +48,7 @@ func NewUpgrade(cfg env.Config) *Upgrade {
 		cleanupOnFail:   cfg.CleanupOnFail,
 		certs:           newRepoCerts(cfg),
 		createNamespace: cfg.CreateNamespace,
+		skipCrds:        cfg.SkipCrds,
 	}
 }
 
@@ -99,6 +101,9 @@ func (u *Upgrade) Prepare() error {
 	}
 	if u.createNamespace {
 		args = append(args, "--create-namespace")
+	}
+	if u.skipCrds {
+		args = append(args, "--skip-crds")
 	}
 	for _, vFile := range u.valuesFiles {
 		args = append(args, "--values", vFile)

--- a/internal/run/upgrade_test.go
+++ b/internal/run/upgrade_test.go
@@ -220,3 +220,27 @@ func (suite *UpgradeTestSuite) TestPrepareDebugFlag() {
 	suite.Equal(want, stderr.String())
 	suite.Equal("", stdout.String())
 }
+
+func (suite *UpgradeTestSuite) TestPrepareSkipCrdsFlag() {
+	defer suite.ctrl.Finish()
+
+	cfg := env.Config{
+		Chart:    "at40",
+		Release:  "cabbages_smell_great",
+		SkipCrds: true,
+	}
+	u := NewUpgrade(cfg)
+
+	command = func(path string, args ...string) cmd {
+		suite.Equal(helmBin, path)
+		suite.Equal([]string{"upgrade", "--install", "--skip-crds", "cabbages_smell_great", "at40"}, args)
+
+		return suite.mockCmd
+	}
+
+	suite.mockCmd.EXPECT().Stdout(gomock.Any())
+	suite.mockCmd.EXPECT().Stderr(gomock.Any())
+
+	err := u.Prepare()
+	suite.Require().Nil(err)
+}


### PR DESCRIPTION
Signed-off-by: George Kaz <egeorgekaz@gmail.com>

Adds support for --skip-crds which helm supports but this plugin does not.
Also updates to helm 3.6.2 because, well, why not?!

Pre-merge checklist:

* [X] Code changes have tests
* [X] Any config changes are documented:
    * If the change touches _required_ config, there's a corresponding update to `README.md`
    * There's a corresponding update to `docs/parameter_reference.md`
    * There's a pull request to update [the parameter reference in drone-plugin-index](https://github.com/drone/drone-plugin-index/blob/master/content/pelotech/drone-helm3/index.md)
* [X] Any large changes have been verified by running a Drone job
