### PR TITLE
WIP: support github runner action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
+FROM golang:1.13
+
+WORKDIR /src
+COPY . /src/
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /src/build/drone-helm /src/cmd/drone-helm/main.go
+
 FROM alpine/helm:3.8.1
 MAINTAINER Joachim Hill-Grannec <joachim@pelo.tech>
 
-COPY build/drone-helm /bin/drone-helm
-COPY assets/kubeconfig.tpl /root/.kube/config.tpl
+COPY --from=0 /src/build/drone-helm /bin/drone-helm
+COPY --from=0 /src/assets/kubeconfig.tpl /root/.kube/config.tpl
 
 LABEL description="Helm 3 plugin for Drone 3"
 LABEL base="alpine/helm"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,55 @@
+---
+name: 'Helm3'
+description: "This plugin provides an interface to Helm 3"
+inputs:
+  mode:
+    description: "Indicates the operation to perform. Recommended, but not required. Valid options are `upgrade`, `uninstall`, `lint`, and `help`."
+    required: true
+  chart:
+    description: "The chart to use for this installation."
+    required: false
+  release:
+    description: "The release name for helm to use."
+    required: false
+  namespace:
+    description: "Kubernetes namespace to use for this operation."
+    required: false
+  values:
+    description: "Chart values to use as the `--set` argument to `helm upgrade`."
+    required: false
+  debug:
+    description: "Generate debug output within drone-helm3 and pass `--debug` to all helm commands. Use with care, since the debug output may include secrets."
+    required: false
+    default: "false"
+  skip_tls_verify:
+    description: "Connect to the Kubernetes cluster without checking for a valid TLS certificate. Not recommended in production. This is ignored if `skip_kubeconfig` is `true`."
+    required: false
+    default: "false"
+  kube_certificate:
+    description: "Base64 encoded TLS certificate used by the Kubernetes cluster's certificate authority. This is ignored if `skip_kubeconfig` is `true`."
+    required: false
+  kube_api_server:
+    description: "API endpoint for the Kubernetes cluster. This is ignored if `skip_kubeconfig` is `true`."
+    required: false
+  kube_token:
+    description: "Token for authenticating to Kubernetes. This is ignored if `skip_kubeconfig` is `true`."
+    required: false
+  kube_service_account:
+    description: "Service account for authenticating to Kubernetes. Default is `helm`. This is ignored if `skip_kubeconfig` is `true`."
+    required: false
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.mode }}
+    - ${{ inputs.chart }}
+    - ${{ inputs.release }}
+    - ${{ inputs.namespace }}
+    - ${{ inputs.values }}
+    - ${{ inputs.debug }}
+    - ${{ inputs.skip_tls_verify }}
+    - ${{ inputs.kube_certificate }}
+    - ${{ inputs.kube_api_server }}
+    - ${{ inputs.kube_token }}
+    - ${{ inputs.kube_service_account }}


### PR DESCRIPTION
`Feature`: This is an initial draft idea to add support for [github action](https://github.com/features/actions) there are few plugin already available in the market place but not good as this. So far the test are success but I would like to know your thoughts before make more changes/test.

This feature was control by environment var i.e `runner` when set to 'github', the `envcofig` prefix was set to `INPUT` (default is `PLUGIN`)

Sample Github Workflow
----------------------------------
```yaml
---
on: 
  push:
    branches:
      - master
jobs: 
  publish:
    runs-on: vm
    name: Deploy using Helm3
    needs: [build, lint]
    steps:
      - name: Checkout helm chart
        uses: actions/checkout@v3
        with:
          repository: spawnlab-dev/helm-spawnlab-apis
          token: ${{ secrets.PAT_TOKEN }}
          path: "spawnlab-apis"
  
      - name: Run lint
        env:
          runner: "github"
        id: helm-lint
        uses: spawnlab-dev/drone-helm3@pmishra/github_action
        with:
          mode: lint
          chart: ./spawnlab-apis
```
 
![Screenshot 2023-10-09 at 14 10 57](https://github.com/pelotech/drone-helm3/assets/6874494/37fc2d46-2991-42d8-8aa7-792077f42d53)

Pre-merge checklist:

* [x] Code changes have tests
* [ ] Any config changes are documented:
    * If the change touches _required_ config, there's a corresponding update to `README.md`
    * There's a corresponding update to `docs/parameter_reference.md`
    * There's a pull request to update [the parameter reference in drone-plugin-index](https://github.com/drone/drone-plugin-index/blob/master/content/pelotech/drone-helm3/index.md)
* [x] Any large changes have been verified by running a Drone job
